### PR TITLE
Making grammar and case of headings consistent

### DIFF
--- a/about.md
+++ b/about.md
@@ -12,7 +12,7 @@ Library Carpentry is in the commons and for the commons. It is not tied to any i
 
 ______
 
-## What is a workshop
+## What is a Workshop?
 
 A Library Carpentry workshop comprises one or more half-day, face-to-face sessions where one or more of the currently developed modules are taught. Ideally, 4 modules (e.g, Data Intro, Shell, Git, OpenRefine) will be taught in a workshop across four half-day sessions, but this is not mandatory. Organisers may prefer to teach the workshop over two or more days. While the original material is key, organisers may choose to swap in the SQL module to replace one of the core lessons, or teach it in addition. Workshops are interactive. Ideally attendees will bring their own laptop to workshop so that skills learnt can be replicated outside of the workshop without the need for additional setup.
 
@@ -27,19 +27,19 @@ To maintain the quality of Library Carpentry workshops, it is highly recommend t
 
 ______
 
-## What is a module
+## What is a Module?
 
 A Library Carpentry module is a set of training materials that can be used either to run a half-day, face-to-face training session or as self-directed learning. Each module comprises 3-4 sections, is interactive, works across Windows, OS X, and Linux operating systems (with all setup instructions included) and has a combination of follow-my-leader sections and exercises (and additional exercises) that map to library practice. Modules introduce software and concepts relevant to librarians and have a preference for open source and widely used software. Data used in exercises is library-related, e.g. bibliographic data.
 
 ______
 
-## Who is an instructor
+## Who is an Instructor?
 
 A Library Carpentry instructor is anyone willing to lead a Library Carpentry workshop. There are at present no prerequisites or training required to run a workshop. Going forward we will continue to evaluate this, mindful of the success of the Software Carpentry [Instructor Training](http://swcarpentry.github.io/instructor-training/) approach and with the ambition for the lead instructor of every Library Carpentry workshop to have undergone Software Carpentry [Instructor Training](http://swcarpentry.github.io/instructor-training/)
 
 ______
 
-## How Library Carpentry is managed
+## How is Library Carpentry Managed?
 
 Library Carpentry was developed and is maintained by volunteers. There is no central organisation or command structure, and all activity is - at present - voluntary.  Management and maintenance are distributed. Each module is 'owned' by one of more individuals responsible for coordinating maintenance of that module. Changes to lessons are managed using the GitHub Issue tracker. Announcements and initial discussion take place on [Gitter](https://gitter.im/weaverbel/LibraryCarpentry). New members are welcome to join this community.
 


### PR DESCRIPTION
Headings in `about.md` were inconsistent (some questions, some not, some with title casing, some without) - this makes them consistent.