### PR TITLE
Fix 'FAQs' heading on outline page

### DIFF
--- a/_posts/2015-07-03-outline.md
+++ b/_posts/2015-07-03-outline.md
@@ -38,7 +38,7 @@ The programme is subject to change depending on how we get along, what you want,
 - Cleaning Data with Open Refine
 - Doing more with Open Refine
 
-##FAQS...
+## FAQS...
 
 *Do I need to bring a laptop to Library Carpentry?*
 


### PR DESCRIPTION
GH Pages requires a space between the `##` characters and the rest of the heading