### PR TITLE
move blog post notice to the bottom of post list

### DIFF
--- a/_layouts/frontpage.html
+++ b/_layouts/frontpage.html
@@ -95,8 +95,15 @@ format: frontpage
 
 
         <div class="medium-6 columns">
-            <p><strong>{{ site.data.language.more_articles }}</strong></p>
-            {% include list-posts entries='3' offset='1' %}
+          <p><strong>{{ site.data.language.more_articles }}</strong></p>
+          {% include list-posts entries='5' offset='1' %}
+          <p style="font-size: small; font-style: italic;">
+          In addition of the posts above,
+          find out what's happening in our community through
+          <a href="https://carpentries.org/blog">The Carpentries blog</a>,
+          a great resource that collates posts from Data Carpentry,
+          Library Carpentry, and Software Carpentry, and
+          publishes updates of general interest to the community.
         </div><!-- /.medium-7.columns -->
     </div><!-- /.row -->
 {% endunless %}


### PR DESCRIPTION
Another proposal:

- add more recent blog post to the list to balance the text from the notice
- put the notice at the bottom, smaller font, using italic

![screenshot from 2019-02-11 12-49-51](https://user-images.githubusercontent.com/5502922/52582608-8ef56980-2dfb-11e9-8b8c-11a8c1e96cb0.png)
