### PR TITLE
add navigation by author and tag

### DIFF
--- a/_includes/_meta_information.html
+++ b/_includes/_meta_information.html
@@ -1,13 +1,13 @@
 			<div id="page-meta" class="t30">
 			  <p>
-			       {% for author in page.authors %}<span itemprop="author" itemscope itemtype="http://schema.org/Person"><span itemprop="name" class="pr20 icon-edit">{{ author }}</span></span>{% endfor %}
+			    {% for author in page.authors %}<span itemprop="author" itemscope itemtype="http://schema.org/Person"><span itemprop="name" class="pr20 icon-edit"><a href="{% link blog/browse_by_author.md %}#blog-author-{{ author | slugify: 'pretty'}}">{{ author }}</a></span></span>{% endfor %}
 
 				{% if page.date %}
 				<time class="icon-calendar pr20" datetime="{{ page.date | date_to_xmlschema }}" itemprop="datePublished"> {{ page.date | date: "%Y-%m-%d" }}</time>
 				{% endif %}
 
 				<br />
-				<span class="pr20">{% for tag in page.tags %}<span class="icon-price-tag pr10"> {{tag}}</span> {% endfor %}</span>
+                                <span class="pr20">{% for tag in page.tags %}<span class="icon-price-tag pr10"> <a href="{% link blog/browse_by_tag.md %}#blog-tag-{{ tag | slugify: 'pretty'}}">{{tag}}</a></span> {% endfor %}</span>
 			</p>
 
 			{% if page.collection == "posts" %}

--- a/_includes/expand-side-column
+++ b/_includes/expand-side-column
@@ -1,0 +1,16 @@
+{% comment %}
+* when the side column with the tags is displayed, we need to make it
+* as tall as the other side of the page, so the stickyness of the
+* 'back to the top' works. This jQuery is activated when scrolling happens
+* and checks that the screen is 628px wide to change the height of the column
+{% endcomment %}
+<script>
+  $( window ).scroll(function() {
+  if (window.innerWidth > 628) {
+        $(".list-tags").css({'height':($(".list-posts").height()+'px')});
+  }
+  else {
+        $(".list-tags").css({'height': '100%'});
+  }
+ });
+</script>

--- a/_includes/list-by-author
+++ b/_includes/list-by-author
@@ -1,0 +1,29 @@
+{% comment %}
+*
+*   Possible parameter for this loop:
+*
+*    › entries
+*    › offset
+*    › author
+*
+*   Example for Tag: {% include list-by-author entries='5' author='terminal' %}
+*
+{% endcomment %}
+
+
+
+{% assign author = include.author %}
+{% assign post_author = site.posts | where_exp: "item", "item.authors contains author" %}
+<ul>
+
+    {% for post in post_author limit:include.entries %}
+      <li><a href="{{ site.url }}{{ site.baseurl }}{{ post.url }}">{% if post.subheadline %}{{ post.subheadline }} &middot; {% endif %}<strong>{{ post.title }}</strong></a>
+      <p class="post-meta">
+      {% if post.date %}
+	<time class="icon-calendar pr20" datetime="{{ post.date | date_to_xmlschema }}" itemprop="datePublished"> {{ post.date | date: "%Y-%m-%d" }}</time>
+	{% endif %}
+        </p>
+      </li>
+    {% endfor %}
+
+</ul>

--- a/_includes/list-by-tag
+++ b/_includes/list-by-tag
@@ -1,0 +1,28 @@
+{% comment %}
+*
+*   Possible parameter for this loop:
+*
+*    › entries
+*    › offset
+*    › tag
+*
+*   Example for Tag: {% include list-posts entries='5' tag='terminal' %}
+*
+{% endcomment %}
+
+
+
+{% assign tag = include.tag %}
+<ul>
+
+    {% for post in site.tags.[tag] limit:include.entries %}
+      <li><a href="{{ site.url }}{{ site.baseurl }}{{ post.url }}">{% if post.subheadline %}{{ post.subheadline }} &middot; {% endif %}<strong>{{ post.title }}</strong></a>
+      <p class="post-meta">
+      {% if post.date %}
+	<time class="icon-calendar pr20" datetime="{{ post.date | date_to_xmlschema }}" itemprop="datePublished"> {{ post.date | date: "%Y-%m-%d" }}</time>
+	{% endif %}
+        </p>
+      </li>
+    {% endfor %}
+
+</ul>

--- a/_includes/n-post-by-author
+++ b/_includes/n-post-by-author
@@ -1,0 +1,21 @@
+{% comment %}
+*
+*   Possible parameter for this loop:
+*
+*    › author
+*
+*   Example for Tag: {% include n-post-by-author author='terminal' %}
+*
+{% endcomment %}
+
+
+
+{% assign author = include.author %}
+{% assign post_author = site.posts | where_exp: "item", "item.authors contains author" %}
+
+{% assign n = 0 %}
+
+{% for post in post_author %}
+{% assign n = n | plus: 1 %}
+{% endfor %}
+({{ n }})

--- a/_includes/n-post-by-tag
+++ b/_includes/n-post-by-tag
@@ -1,0 +1,19 @@
+{% comment %}
+*
+*   Possible parameter for this loop:
+*
+*    › tag
+*
+*   Example for Tag: {% include n-post-by-tag tag='terminal' %}
+*
+{% endcomment %}
+
+
+
+{% assign tag = include.tag %}
+{% assign n = 0 %}
+
+{% for post in site.tags.[tag] %}
+{% assign n = n | plus: 1 %}
+{% endfor %}
+({{ n }})

--- a/_sass/_06_typography.scss
+++ b/_sass/_06_typography.scss
@@ -90,7 +90,18 @@ h1, h2, h3, h4, h5, h6 {
     font-weight: normal;
     padding: 0;
 }
-
+h1[id]:before,
+h2[id]:before,
+h3[id]:before,
+h4[id]:before {
+    display: block;
+    content: " ";
+    margin-top: -50px;
+    height: 50px;
+    visibility: hidden;
+    position: relative;
+    z-index: -1;
+}
 h1 {
     font-size: $font-size-h1;
     margin-top: 0;

--- a/blog/browse_by_author.md
+++ b/blog/browse_by_author.md
@@ -1,0 +1,63 @@
+---
+layout: default
+title: "Library Carpentry Blog Authors"
+teaser: "Browse posts on the Library Carpentry blog by authors"
+comments: false
+permalink: "/posts-by-authors/"
+---
+
+{% include expand-side-column %}
+
+{% comment %}
+* hack to create an empty array
+{% endcomment %}
+{% assign all_authors = "" | split: "," %}
+
+{% comment %}
+* create an array of all authors. Needed to get them in alphabetical order
+{% endcomment %}
+{% for p in site.posts %}
+{% for a in p.authors %}
+{% assign all_authors = all_authors | push: a  %}
+{% endfor %}
+{% endfor %}
+
+{% assign all_authors = all_authors | uniq | sort %}
+
+<div class="row t30">
+
+<div class="medium-8 column list-posts">
+
+  <div itemprop="name">
+  <h1>{{ page.title }}</h1>
+  </div>
+  
+  <p class="teaser" itemprop="description">
+    {{ page.teaser }}
+  </p>
+  
+{% for a in all_authors %}
+{% assign a_pretty = a | slugify: 'pretty' %}  
+<h2 id="blog-author-{{ a_pretty }}">{{ a }}</h2>
+
+{% include list-by-author author=a %}
+{% endfor %}
+</div>
+
+<div class="medium-4 column list-tags">
+<h2><small>List of Authors</small></h2>
+<ul>
+{% for a in all_authors %}
+{% assign a_pretty = a | slugify: 'pretty' %}  
+<li><a href="#blog-author-{{a_pretty}}">{{ a }}</a> {% include n-post-by-author author=a %}</li>
+{% endfor %}
+</ul>
+
+<div style="position: sticky; top: 4rem;">
+  <a href="#top-of-page"><i class="fas fa-chevron-up"></i> Back to the top</a>
+</div>
+
+
+</div>
+
+</div>

--- a/blog/browse_by_tag.md
+++ b/blog/browse_by_tag.md
@@ -1,0 +1,61 @@
+---
+layout: default
+title: "Library Carpentry Blog Tags"
+teaser: "Browse the posts on the Library Carpentry blog by tags"
+comments: false
+permalink: "/posts-by-tags/"
+---
+
+{% include expand-side-column %}
+
+{% comment %}
+* hack to create an empty array
+{% endcomment %}
+{% assign all_tags = "" | split: "," %}
+
+{% comment %}
+* create an array of all tags. Needed to get them in alphabetical order
+{% endcomment %}
+{% for t in site.tags %}
+{% assign all_tags = all_tags | push: t[0]  %}
+{% endfor %}
+
+{% assign all_tags = all_tags | sort %}
+
+<div class="row t30">
+
+<div class="medium-8 column list-posts">
+
+  <div itemprop="name">
+  <h1>{{ page.title }}</h1>
+  </div>
+
+  <p class="teaser" itemprop="description">
+    {{ page.teaser }}
+  </p>
+
+{% for t in all_tags %}
+{% assign t_pretty = t | slugify: 'pretty' %}
+<h2 id="blog-tag-{{ t_pretty }}">{{ t }}</h2>
+
+{% include list-by-tag tag=t %}
+{% endfor %}
+</div>
+
+<div class="medium-4 column list-tags">
+<h2><small>List of tags</small></h2>
+<ul>
+{% for t in all_tags %}
+{% assign t_pretty = t | slugify: 'pretty' %}
+<li><a href="#blog-tag-{{t_pretty}}">{{ t }}</a> {% include n-post-by-tag tag=t %}</li>
+{% endfor %}
+</ul>
+
+<div style="position: sticky; top: 4rem;">
+  <a href="#top-of-page"><i class="fas fa-chevron-up"></i> Back to the top</a>
+</div>
+
+
+</div>
+
+</div>


### PR DESCRIPTION
Similarly to a feature brought a few months ago to the Carpentries site, this PR introduces navigation by authors and tags across blog posts. 