### PR TITLE
updating lead change for the python group

### DIFF
--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -135,7 +135,7 @@ Lesson materials are all available online, under a CC BY license, for self-direc
       <td><a href="https://librarycarpentry.org/lc-python-intro/reference.html" target="_blank" class="icon-eye" title="Reference for Introduction to Python lesson"></a></td>
       <td><a href="https://librarycarpentry.org/lc-python-intro/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for Introduction to Python lesson"></a></td>
       <td>Alpha</td>
-      <td>Laura Wrubel*, Konrad Foerstner, Drew Heles, Elizabeth Wickes (Past Maintainers: Carlos Martinez, Richard Vankoningsveld)</td>
+      <td>Elizabeth Wickes*, Laura Wrubel, Konrad Foerstner, Drew Heles (Past Maintainers: Carlos Martinez, Richard Vankoningsveld)</td>
    </tr>
    <tr>
       <td>Introduction to Data for Archivists</td>


### PR DESCRIPTION
Python lesson leadership changed for 2020, putting in PR representing that update.