### PR TITLE
Move Thea to past maintainer

### DIFF
--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -78,7 +78,7 @@ Lesson materials are all available online, under a CC BY license, for self-direc
       <td><a href="https://librarycarpentry.org/lc-git/reference.html" target="_blank" class="icon-eye" title="Reference for Introduction to Git lesson"></a></td>
       <td><a href="https://librarycarpentry.org/lc-git/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for Introduction to Git lesson"></a></td>
       <td>Beta</td>
-      <td>Silvia di Giorgio, Thea Atwood, Eric Lopatin, Drew Heles, Eva Seidlmayer, Christopher Felker, Chuck McAndrew (Past Maintainers: Katrin Leinweber, Belinda Weaver, Jez Cope, Chris Erdmann)</td>
+      <td>Silvia di Giorgio, Eric Lopatin, Drew Heles, Eva Seidlmayer, Christopher Felker, Chuck McAndrew (Past Maintainers: Thea Atwood, Katrin Leinweber, Belinda Weaver, Jez Cope, Chris Erdmann)</td>
    </tr>
 </table>
 <hr />


### PR DESCRIPTION
Thea Atwood is no longer a maintainer on the Git lesson. Moved to past maintainers list at their request.
