### PR TITLE
Moving lc-carpentry to stable status

### DIFF
--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -116,7 +116,7 @@ Lesson materials are all available online, under a CC BY license, for self-direc
       <td><a href="https://github.com/librarycarpentry/lc-spreadsheets/" target="_blank" class="icon-github" title="Repository for Tidy Data lesson"></a></td>
       <td><a href="https://librarycarpentry.org/lc-spreadsheets/reference.html" target="_blank" class="icon-eye" title="Reference for Tidy Data lesson"></a></td>
       <td><a href="https://librarycarpentry.org/lc-spreadsheets/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for Tidy Data lesson"></a></td>
-      <td>Beta</td>
+      <td>Stable</td>
       <td>Sherry Lake*, Tim Dennis, Thea Atwood, Erika Mias (Past Maintainer: Jez Cope)</td>
    </tr>
    <tr>


### PR DESCRIPTION
Moving https://github.com/LibraryCarpentry/lc-spreadsheets to stable status on lesson page on library carpentry.