### PR TITLE
Move lc-git to stable

### DIFF
--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -77,7 +77,7 @@ Lesson materials are all available online, under a CC BY license, for self-direc
       <td><a href="https://github.com/librarycarpentry/lc-git/" target="_blank" class="icon-github" title="Repository for Introduction to Git lesson"></a></td>
       <td><a href="https://librarycarpentry.org/lc-git/reference.html" target="_blank" class="icon-eye" title="Reference for Introduction to Git lesson"></a></td>
       <td><a href="https://librarycarpentry.org/lc-git/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for Introduction to Git lesson"></a></td>
-      <td>Beta</td>
+      <td>Stable</td>
       <td>Silvia di Giorgio, Eric Lopatin, Drew Heles, Christopher Felker, Chuck McAndrew (Past Maintainers: Eva Seidlmayer, Thea Atwood, Katrin Leinweber, Belinda Weaver, Jez Cope, Chris Erdmann)</td>
    </tr>
 </table>


### PR DESCRIPTION
Closes #102 
Changes lc-git status to stable on https://librarycarpentry.org/lessons/.