### PR TITLE
Moved R Lesson to Extended Curriculum section

### DIFF
--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -146,6 +146,15 @@ Lesson materials are all available online, under a CC BY license, for self-direc
       <td>Alpha</td>
       <td>Katherine Koziar*, Jeanine Finn, and Scott Peterson (Past Maintainers: Jenny Bunn, Noah Geraci, and James Baker)</td>
    </tr>
+   <tr>
+      <td>Introduction to R</td>
+      <td><a href="https://librarycarpentry.org/lc-r/" target="_blank" class="icon-browser" title="Website for the Introduction to R lesson"></a></td>
+      <td><a href="https://github.com/librarycarpentry/lc-r/" target="_blank" class="icon-github" title="Repository for Introduction to R lesson"></a></td>
+      <td><a href="https://librarycarpentry.org/lc-r/reference.html" target="_blank" class="icon-eye" title="Reference for Introduction to R lesson"></a></td>
+      <td><a href="https://librarycarpentry.org/lc-r/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for Introduction to R lesson"></a></td>
+      <td>Alpha</td>
+      <td>Clarke Iakovakis*, John Little, Stéphane Guillou, Tim Dennis (looking for Maintainers)</td>
+   </tr>
 </table>
 <hr />
 
@@ -224,15 +233,6 @@ Lesson materials are all available online, under a CC BY license, for self-direc
       <td><a href="https://librarycarpentry.org/lc-fair-research/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for FAIR Data & Software lesson"></a></td>
       <td>Conceptual</td>
       <td>Chris Erdmann*, Liz Stokes, Kristina Hettne, Carmi Cronje (looking for Maintainers)</td>
-   </tr>
-   <tr>
-      <td>Introduction to R</td>
-      <td><a href="https://librarycarpentry.org/lc-r/" target="_blank" class="icon-browser" title="Website for the Introduction to R lesson"></a></td>
-      <td><a href="https://github.com/librarycarpentry/lc-r/" target="_blank" class="icon-github" title="Repository for Introduction to R lesson"></a></td>
-      <td><a href="https://librarycarpentry.org/lc-r/reference.html" target="_blank" class="icon-eye" title="Reference for Introduction to R lesson"></a></td>
-      <td><a href="https://librarycarpentry.org/lc-r/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for Introduction to R lesson"></a></td>
-      <td>Conceptual</td>
-      <td>Clarke Iakovakis*, John Little, Stéphane Guillou, Tim Dennis (looking for Maintainers)</td>
    </tr>
    <tr>
       <td>XML</td>


### PR DESCRIPTION
This lesson is now in Alpha and has been moved from Conceptual to Extended Curriculum

I think I updated the table correctly!
