### PR TITLE
Update lessons.html

### DIFF
--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -218,8 +218,8 @@ Lesson materials are all available online, under a CC BY license, for self-direc
    </tr>
    <tr>
       <td>Wikidata</td>
-      <td><a href="https://github.com/LibraryCarpentry/lc-wikidata" target="_blank" class="icon-browser" title="Website for Wikidata lesson"></a></td>
-      <td><a href="https://github.com/librarycarpentry/lc-wikidata/" target="_blank" class="icon-github" title="Repository for Wikidata lesson"></a></td>
+      <td><a href="https://librarycarpentry.org/lc-wikidata/" target="_blank" class="icon-browser" title="Website for Wikidata lesson"></a></td>
+      <td><a href="https://github.com/LibraryCarpentry/lc-wikidata" target="_blank" class="icon-github" title="Repository for Wikidata lesson"></a></td>
       <td><a href="https://librarycarpentry.org/lc-wikidata/reference.html" target="_blank" class="icon-eye" title="Reference for Wikidata lesson"></a></td>
       <td><a href="https://librarycarpentry.org/lc-wikidata/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for Wikidata lesson"></a></td>
       <td>Conceptual</td>


### PR DESCRIPTION
Corrected the website link and formatted the repository link for wikidata.

Proposal 1 of 2)
Proposed website link: (different link)
https://librarycarpentry.org/lc-wikidata/

Current website link:
https://github.com/LibraryCarpentry/lc-wikidata


Proposal 2 of 2)
Proposed website link: (same link but case-corrected)
https://github.com/LibraryCarpentry/lc-wikidata

Current repository link:
https://github.com/librarycarpentry/lc-wikidata