### PR TITLE
update lc-fair-research site link in lessons page

### DIFF
--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -227,8 +227,8 @@ Lesson materials are all available online, under a CC BY license, for self-direc
    </tr>
    <tr>
       <td>FAIR Data & Software</td>
-      <td><a href="https://github.com/LibraryCarpentry/lc-fair-research" target="_blank" class="icon-browser" title="Website for FAIR Data & Software lesson"></a></td>
-      <td><a href="https://github.com/librarycarpentry/lc-fair-research" target="_blank" class="icon-github" title="Repository for FAIR Data & Software lesson"></a></td>
+      <td><a href="https://librarycarpentry.org/lc-fair-research/" target="_blank" class="icon-browser" title="Website for FAIR Data & Software lesson"></a></td>
+      <td><a href="https://github.com/LibraryCarpentry/lc-fair-research" target="_blank" class="icon-github" title="Repository for FAIR Data & Software lesson"></a></td>
       <td><a href="https://librarycarpentry.org/lc-fair-research/reference.html" target="_blank" class="icon-eye" title="Reference for FAIR Data & Software lesson"></a></td>
       <td><a href="https://librarycarpentry.org/lc-fair-research/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for FAIR Data & Software lesson"></a></td>
       <td>Conceptual</td>


### PR DESCRIPTION
Corrected the website link and formatted the repository link for lc-fair-research.

Proposal 1 of 2)
Proposed website link: (different link)
https://librarycarpentry.org/lc-fair-research/

Current website link:
https://github.com/LibraryCarpentry/lc-fair-research


Proposal 2 of 2)
Proposed website link: (same link but case-corrected)
https://github.com/LibraryCarpentry/lc-fair-research

Current repository link:
https://github.com/librarycarpentry/lc-fair-research