### PR TITLE
Workshop style Self/Centrally-Organised

### DIFF
--- a/pages/contact.md
+++ b/pages/contact.md
@@ -16,7 +16,7 @@ There are several ways to get in touch.
 
 * Secondary Chatroom on Gitter:  Library Carpentry [Lobby](https://gitter.im/LibraryCarpentry/Lobby) or [Top 10 FAIR](https://gitter.im/LibraryCarpentry/Top10FAIR)). We use Gitter during global and lesson sprints.
 
-* [Request a Library Carpentry Workshop](https://amy.carpentries.org/forms/workshop/) or register your self-organised workshop. Note your interest in Library Carpentry.
+* [Request a Library Carpentry Workshop](https://amy.carpentries.org/forms/workshop/) or register your Self-Organised workshop. Note your interest in Library Carpentry.
 
 * Submit Issues/Pull Requests to Our Lessons and Website: [Library Carpentry GitHub Organisation](https://github.com/LibraryCarpentry). We also use the Library Carpentry GitHub Organisation for Curriculum Advisory Committee and Advisory Group discussions and decisions via the [governance repository](https://github.com/LibraryCarpentry/governance).
 

--- a/pages/past_workshops.html
+++ b/pages/past_workshops.html
@@ -8,7 +8,7 @@ This page lists past Library Carpentry workshops.  Don't see a workshop in your 
 
 <br /><br /> 
   
-If you would like to make an inquiry, request a workshop, or register a self-organised workshop, visit <a href="https://amy.carpentries.org/forms/workshop/">The Carpentries workshop form</a>. Once your request has been recorded and your workshop is scheduled, it will be listed on this page.
+If you would like to make an inquiry, request a workshop, or register a Self-Organised workshop, visit <a href="https://amy.carpentries.org/forms/workshop/">The Carpentries workshop form</a>. Once your request has been recorded and your workshop is scheduled, it will be listed on this page.
 
 <br /><br />
 

--- a/pages/upcoming_workshops.html
+++ b/pages/upcoming_workshops.html
@@ -8,7 +8,7 @@ This page lists upcoming Library Carpentry workshops. Don't see a workshop in yo
 
 <br /><br /> 
   
-If you would like to make an inquiry, request a workshop, or register a self-organised workshop, visit <a href="https://amy.carpentries.org/forms/workshop/">The Carpentries workshop form</a>. Once your request has been recorded and your workshop is scheduled, it will be listed on this page.
+If you would like to make an inquiry, request a workshop, or register a Self-Organised workshop, visit <a href="https://amy.carpentries.org/forms/workshop/">The Carpentries workshop form</a>. Once your request has been recorded and your workshop is scheduled, it will be listed on this page.
 
 <br /><br />
 

--- a/pages/workshops.md
+++ b/pages/workshops.md
@@ -14,7 +14,7 @@ Prior to and following each workshop, instructors have surveys available to them
 
 Our lesson materials are collaboratively developed by our volunteer community. All of our lessons are open source, and are hosted on [GitHub](https://github.com/librarycarpentry). 
 
-To request a workshop at your institution or to register your self-organised workshop, visit the [The Carpentries](https://amy.carpentries.org/forms/workshop/) workshop request page. Indicate in the form that you are interested in hosting a Library Carpentry workshop. If you're interested other ways Library Carpentry lessons can be used at your site, please contact [team@carpentries.org](mailto:team@carpentries.org). Please note, our workshop workflow is undergoing updates (see [Introducing updated Workshop Request Forms and More](https://carpentries.org/blog/2019/09/Workshop-request-forms-and-more/)). 
+To request a workshop at your institution or to register your Self-Organised workshop, visit the [The Carpentries](https://amy.carpentries.org/forms/workshop/) workshop request page. Indicate in the form that you are interested in hosting a Library Carpentry workshop. If you're interested other ways Library Carpentry lessons can be used at your site, please contact [team@carpentries.org](mailto:team@carpentries.org). Please note, our workshop workflow is undergoing updates (see [Introducing updated Workshop Request Forms and More](https://carpentries.org/blog/2019/09/Workshop-request-forms-and-more/)). 
 
 The Carpentries team of [Regional Coordinators](https://carpentries.org/regionalcoordinators/) supports workshop activity in various global regions. These teams can connect you with regional communities.
 


### PR DESCRIPTION
Per guidance from @sheraaronhurt and @kmomar this standardizes the text style as follows:

Self-Organised workshop and Centrally-Organised workshop. Capital letters, separated by hyphen, British spelling.
