### PR TITLE
maintainers in alpha order

### DIFF
--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -42,7 +42,7 @@ Lesson materials are all available online, under a CC BY license, for self-direc
       <td><a href="https://librarycarpentry.org/lc-overview/reference.html" target="_blank" class="icon-eye" title="Reference for Workshop Overview"></a></td>
       <td><a href="https://librarycarpentry.org/lc-overview/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for Workshop Overview"></a></td>
       <td>Stable</td>
-      <td>Shari Laster*, Carmi Cronje, Paul R. Pival, Anton Angelo</td>
+      <td>Anton Angelo, Carmi Cronje, Shari Laster*, Paul R. Pival</td>
    </tr>
    <tr>
       <td>Introduction to Working with Data (Regular Expressions)</td>
@@ -51,7 +51,7 @@ Lesson materials are all available online, under a CC BY license, for self-direc
       <td><a href="https://librarycarpentry.org/lc-data-intro/reference.html" target="_blank" class="icon-eye" title="Reference for Introduction to Data lesson"></a></td>
       <td><a href="https://librarycarpentry.org/lc-data-intro/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for Introduction to Data lesson"></a></td>
       <td>Stable</td>
-      <td>Shari Laster*, Carmi Cronje, Paul R. Pival, Anton Angelo</td>
+      <td> Anton Angelo, Carmi Cronje, Shari Laster*, Paul R. Pival</td>
    </tr>
    <tr>
       <td>The UNIX Shell</td>
@@ -60,7 +60,7 @@ Lesson materials are all available online, under a CC BY license, for self-direc
       <td><a href="https://librarycarpentry.org/lc-shell/reference.html" target="_blank" class="icon-eye" title="Reference for UNIX Shell lesson"></a></td>
       <td><a href="https://librarycarpentry.org/lc-shell/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for UNIX Shell lesson"></a></td>
       <td>Stable</td>
-      <td>Danielle Kane*, Nilani Ganeshwaran, John Wright, Anna Oates, Jamie Jamison</td>
+      <td>Nilani Ganeshwaran, Jamie Jamison, Danielle Kane*, Anna Oates, John Wright</td>
    </tr>
    <tr>
       <td>OpenRefine</td>
@@ -69,7 +69,7 @@ Lesson materials are all available online, under a CC BY license, for self-direc
       <td><a href="https://librarycarpentry.org/lc-open-refine/reference.html" target="_blank" class="icon-eye" title="Reference for OpenRefine lesson"></a></td>
       <td><a href="https://librarycarpentry.org/lc-open-refine/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for OpenRefine lesson"></a></td>
       <td>Stable</td>
-      <td>Erin Carrillo*, Owen Stephens, Paul R. Pival, Kristin Lee</td>
+      <td>Erin Carrillo*, Kristin Lee, Paul R. Pival, Owen Stephens</td>
    </tr>
    <tr>
       <td>Introduction to Git</td>
@@ -78,7 +78,7 @@ Lesson materials are all available online, under a CC BY license, for self-direc
       <td><a href="https://librarycarpentry.org/lc-git/reference.html" target="_blank" class="icon-eye" title="Reference for Introduction to Git lesson"></a></td>
       <td><a href="https://librarycarpentry.org/lc-git/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for Introduction to Git lesson"></a></td>
       <td>Stable</td>
-      <td>Silvia di Giorgio, Eric Lopatin, Drew Heles, Christopher Felker, Elizabeth McAulay</td>
+      <td>Silvia di Giorgio, Christopher Felker,  Drew Heles, Eric Lopatin,  Elizabeth McAulay</td>
    </tr>
 </table>
 <hr />
@@ -108,7 +108,7 @@ Lesson materials are all available online, under a CC BY license, for self-direc
       <td><a href="https://librarycarpentry.org/lc-sql/reference.html" target="_blank" class="icon-eye" title="Reference for SQL lesson"></a></td>
       <td><a href="https://librarycarpentry.org/lc-sql/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for SQL lesson"></a></td>
       <td>Stable</td>
-      <td>Kristin Lee, Chris Erdmann, Lise Doucette, Jacqueline Frisina, Jesse Lambertson, Julika Mimkes</td>
+      <td>Lise Doucette, Chris Erdmann, Jacqueline Frisina, Jesse Lambertson, Kristin Lee, Julika Mimkes</td>
    </tr>
    <tr>
       <td>Tidy Data</td>
@@ -117,7 +117,7 @@ Lesson materials are all available online, under a CC BY license, for self-direc
       <td><a href="https://librarycarpentry.org/lc-spreadsheets/reference.html" target="_blank" class="icon-eye" title="Reference for Tidy Data lesson"></a></td>
       <td><a href="https://librarycarpentry.org/lc-spreadsheets/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for Tidy Data lesson"></a></td>
       <td>Stable</td>
-      <td>Sherry Lake*, Tim Dennis, Thea Atwood, Erika Mias</td>
+      <td>Thea Atwood, Tim Dennis, Sherry Lake*, Erika Mias</td>
    </tr>
    <tr>
       <td>Webscraping</td>
@@ -135,7 +135,7 @@ Lesson materials are all available online, under a CC BY license, for self-direc
       <td><a href="https://librarycarpentry.org/lc-python-intro/reference.html" target="_blank" class="icon-eye" title="Reference for Introduction to Python lesson"></a></td>
       <td><a href="https://librarycarpentry.org/lc-python-intro/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for Introduction to Python lesson"></a></td>
       <td>Alpha</td>
-      <td>Elizabeth Wickes*, Laura Wrubel, Konrad Foerstner, Drew Heles</td>
+      <td>Konrad Foerstner, Drew Heles, Elizabeth Wickes*, Laura Wrubel</td>
    </tr>
    <tr>
       <td>Introduction to Data for Archivists</td>
@@ -144,7 +144,7 @@ Lesson materials are all available online, under a CC BY license, for self-direc
       <td><a href="https://librarycarpentry.org/lc-data-intro-archives/reference.html" target="_blank" class="icon-eye" title="Reference for Introduction to Data for Archivists lesson"></a></td>
       <td><a href="https://librarycarpentry.org/lc-data-intro-archives/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for Introduction to Data for Archivists lesson"></a></td>
       <td>Alpha</td>
-      <td>Katherine Koziar*, Jeanine Finn, and Scott Peterson</td>
+      <td>Jeanine Finn, Katherine Koziar*, Scott Peterson</td>
    </tr>
    <tr>
       <td>Introduction to R</td>
@@ -153,7 +153,7 @@ Lesson materials are all available online, under a CC BY license, for self-direc
       <td><a href="https://librarycarpentry.org/lc-r/reference.html" target="_blank" class="icon-eye" title="Reference for Introduction to R lesson"></a></td>
       <td><a href="https://librarycarpentry.org/lc-r/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for Introduction to R lesson"></a></td>
       <td>Alpha</td>
-      <td>Clarke Iakovakis*, John Little, Stéphane Guillou, Tim Dennis, Sarah Lin</td>
+      <td> Tim Dennis, Stéphane Guillou, Clarke Iakovakis*,  Sarah Lin, John Little</td>
    </tr>
 </table>
 <hr />


### PR DESCRIPTION
Puts lesson maintainers in alpha order, with lead maintainers indicated by asterisk.
Addresses #131 