### PR TITLE
improve contrast on nav hover

### DIFF
--- a/_sass/_01_settings_colors.scss
+++ b/_sass/_01_settings_colors.scss
@@ -37,7 +37,7 @@ $ci-6: #A1D044;		// green
 ---------------------------------------- */
 
 $swc-blue: #000000;       // Software Carpentry dark blue #071159;
-$swc-blue-med: #E20000;	  // Brighter version of Software Carpentry blue #394EEF;
+$swc-blue-med: #CF0000;	  // Brighter version of Software Carpentry blue #394EEF;
 $swc-blue-light: #a60000; // Medium version of Software Carpentry blue #e3e6fd;
 
 /* Foundation Color Variables

--- a/_sass/_01_settings_colors.scss
+++ b/_sass/_01_settings_colors.scss
@@ -37,7 +37,7 @@ $ci-6: #A1D044;		// green
 ---------------------------------------- */
 
 $swc-blue: #000000;       // Software Carpentry dark blue #071159;
-$swc-blue-med: #ffc3ae;	  // Brighter version of Software Carpentry blue #394EEF;
+$swc-blue-med: #E20000;	  // Brighter version of Software Carpentry blue #394EEF;
 $swc-blue-light: #a60000; // Medium version of Software Carpentry blue #e3e6fd;
 
 /* Foundation Color Variables


### PR DESCRIPTION
Improves the colour contrast of hover items in the navigation menu for better accessibility.

Current contrast values: 1.2:1 on active menu items, 1.5:1 on inactive
New values: 4.5:1 on active menu items, 5.7:1 on inactive

Part of #4 