### PR TITLE
Fix broken link and rename link for Data USA

### DIFF
--- a/pages/audience.html
+++ b/pages/audience.html
@@ -90,7 +90,7 @@ information and data. <em>(Instructional)</em></p>
 Review the list of demographic resources as you get to know the Library Carpentry audience and community.</p>
 
 <ul>
-  <li><a href="https://datausa.io/profile/soc/254021/">Data.usa: Librarians</a></li>
+  <li><a href="https://datausa.io/profile/soc/librarians">Data USA: Librarians</a></li>
   <li><a href="http://www.ala.org/tools/sites/ala.org.tools/files/content/Draft%20of%20Member%20Demographics%20Survey%2001-11-2017.pdf">2017 ALA Demographic Study</a></li>
   <li><a href="https://medium.com/@rebeccastavick/libraries-are-not-for-everyone-until-librarianship-can-be-for-everyone-d32d7072970f">Libraries are not for everyone until librarianship can be for everyone</a></li>
 </ul>


### PR DESCRIPTION
The link to the Data USA site for librarians is broken. This change fixes the link and renames "Data.usa" to "Data USA," which is how it is formatted on the site's About page and on the page header.