### PR TITLE
Add hyphens to adjectives and change list item

### DIFF
--- a/pages/audience.html
+++ b/pages/audience.html
@@ -9,11 +9,11 @@ permalink: /audience/
 <ul>
   <li>Who want to explore this material to determine if it is helpful or relevant to their work</li>
   <li>Who face new challenges surrounding data such as learning new tools and practices</li>
-  <li>Who want to improve their workflows and reduce time consuming tasks</li>
+  <li>Who want to improve their workflows and reduce time-consuming tasks</li>
   <li>Who need to gain familiarity and comfort with language surrounding data</li>
   <li>Who would like to collaboratively develop lesson material around information and data</li>
   <li>Who are generally interested in data scholarship</li>
-  <li>Who are looking for a community where they can discuss data related challenges</li>
+  <li>Who are looking for a community where they can discuss data-related challenges</li>
 </ul>
 
 <h3 id="library-carpentry-can-help-you-to">Library Carpentry can help you to…</h2>
@@ -28,7 +28,7 @@ permalink: /audience/
   <li>Support open research and data scholarship</li>
   <li>Foster cultural change within organizations</li>
   <li>Comply with new strategic plans and mission statements</li>
-  <li>Create new opportunities and to reach out to new communities</li>
+  <li>Create new opportunities and reach out to new communities</li>
 </ul>
 
 <h3 id="the-library-carpentry-community-includes-but-is-not-limited-to-the-following-general-profiles">The Library Carpentry community includes, but is not limited to, the following general profiles:</h2>


### PR DESCRIPTION
This change adds some hyphens to a few adjectives for clarity and proposes taking out "to" in "to reach" to match the formatting of other list items. (There's a "to" already in the header.)