### PR TITLE
Remove broken link and suggestions for replacement

### DIFF
--- a/pages/audience.html
+++ b/pages/audience.html
@@ -92,7 +92,6 @@ Review the list of demographic resources as you get to know the Library Carpentr
 <ul>
   <li><a href="https://datausa.io/profile/soc/254021/">Data.usa: Librarians</a></li>
   <li><a href="http://www.ala.org/tools/sites/ala.org.tools/files/content/Draft%20of%20Member%20Demographics%20Survey%2001-11-2017.pdf">2017 ALA Demographic Study</a></li>
-  <li><a href="https://medium.com/@rebeccastavick/libraries-are-not-for-everyone-until-librarianship-can-be-for-everyone-d32d7072970f">Libraries are not for everyone until librarianship can be for everyone</a></li>
 </ul>
 
 <h3 id="job-descriptions-from-the-library-carpentry-community">Job descriptions from the Library Carpentry community:</h2>

--- a/pages/audience.html
+++ b/pages/audience.html
@@ -92,6 +92,8 @@ Review the list of demographic resources as you get to know the Library Carpentr
 <ul>
   <li><a href="https://datausa.io/profile/soc/254021/">Data.usa: Librarians</a></li>
   <li><a href="http://www.ala.org/tools/sites/ala.org.tools/files/content/Draft%20of%20Member%20Demographics%20Survey%2001-11-2017.pdf">2017 ALA Demographic Study</a></li>
+  <li><a href="https://www.libraryjournal.com/section/people">Library Journal's "People" Section</a> - Features Q&As with librarians and editorials on topics like racial equity, book challenges, representation, and the digital divide.</li>
+  <li><a href="https://www.inthelibrarywiththeleadpipe.org/">In the Library with the Lead Pipe</a> - A journal that publishes articles on diversity, equity, and inclusion, providing insights into the library field and current issues faced by librarians.</li>
 </ul>
 
 <h3 id="job-descriptions-from-the-library-carpentry-community">Job descriptions from the Library Carpentry community:</h2>


### PR DESCRIPTION
The Medium essay shared under the section on demographics has been deleted by the author, so the link should be removed.

It might be nice to have a replacement link. In lieu of a specific essay, what about linking to a library blog or journal? For example, _Library Journal_'s "People" section ([https://www.libraryjournal.com/section/people](https://www.libraryjournal.com/section/people)) shares Q&As with librarians in all sorts of jobs, in addition to sharing editorials on topics such racial equity, book challenges, representation, and the digital divide. _In the Library with the Lead Pipe_ ([https://www.inthelibrarywiththeleadpipe.org/](https://www.inthelibrarywiththeleadpipe.org/)) is a journal that often publishes articles relating to diversity, equity, and inclusion. While neither resource is fully centered on demographic information, they could give insight into the library field and what librarians are seeing in their libraries and workplaces.