### PR TITLE
Remove line with unused anchor tag

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,6 @@ and to meet some of our community members.
 3.  If you are comfortable with Git,
     and would like to add or change material,
     you can submit a pull request (PR).
-    Instructions for doing this are [included below](#using-github).
 
 ## Where to Contribute
 


### PR DESCRIPTION
This change removes a line that references a resource on how to submit a pull resource that doesn't exist in the document. The anchor tag leads to nowhere, and I couldn't find it in the contribution guides for other Carpentries repositories to recreate the resource.