### PR TITLE
Fix the link to the "Apply" section

### DIFF
--- a/pages/get_involved.html
+++ b/pages/get_involved.html
@@ -10,7 +10,8 @@ title: "Get Involved"
   <ul>
     <li><a href="#Attend">Attend a workshop</a></li>
     <li><a href="#Volunteer">Volunteer to help with a workshop</a></li>
-    <li><a href="#Host">Host a workshop  Apply to be an instructor</a></li>
+    <li><a href="#Host">Host a workshop</a></li>
+    <li><a href="#Apply">Apply to be an instructor</a></li>
     <li><a href="https://carpentries.org/involved-lessons/">Contribute to our lessons</a></li>
     <li><a href="#Become">Become a member</a></li>
     <li><a href="#What">What's next?</a></li>


### PR DESCRIPTION
The top link list has "Host" and "Apply" on the same line, with no actual link to the "Apply" section. This change fixes that, putting the "Apply" text on its own line and linking to the anchor on the page.