### PR TITLE
Change "others" to include apostrophe

### DIFF
--- a/pages/get_involved.html
+++ b/pages/get_involved.html
@@ -77,5 +77,5 @@ title: "Get Involved"
 </p>
 
 <a name="Read"></a>
-<h3>Read about others experiences</h3>
-<p>We’ve gathered a number of <a href="/our-stories/">stories</a> from the community so that you can read about others experiences. Before you even consider your next steps, learning about what others have done can help.</p> 
+<h3>Read about others’ experiences</h3>
+<p>We’ve gathered a number of <a href="/our-stories/">stories</a> from the community so that you can read about others’ experiences. Before you even consider your next steps, learning about what others have done can help.</p> 

--- a/pages/get_involved.html
+++ b/pages/get_involved.html
@@ -14,7 +14,7 @@ title: "Get Involved"
     <li><a href="https://carpentries.org/involved-lessons/">Contribute to our lessons</a></li>
     <li><a href="#Become">Become a member</a></li>
     <li><a href="#What">What's next?</a></li>
-    <li><a href="#Read">Read about others experiences</a></li>
+    <li><a href="#Read">Read about others’ experiences</a></li>
   </ul>
 </p>
 


### PR DESCRIPTION
This change fixes a typo where "others experiences" isn't possessive and is missing the apostrophe in two places at the end of the page.