### PR TITLE
fix anchor link position

### DIFF
--- a/_sass/_09_elements.scss
+++ b/_sass/_09_elements.scss
@@ -148,3 +148,15 @@ img.lazy {
     transition: opacity 0.7s;
     opacity: 1;
 }
+
+*:target:not([id^='fn:']):not([id^='fnref:']) {
+    &::before {
+        content: " ";
+        width: 0;
+        height: 0;
+
+        display: block;
+        padding-top: 50px;
+        margin-top: -50px;
+    }
+}


### PR DESCRIPTION
Fixes css to add white space around anchor links so they don't get hidden by navbar.
See
carpentries/carpentries.org#1405