### PR TITLE
remove XML lesson from listing

### DIFF
--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -244,15 +244,6 @@ Lesson materials are all available online, under a CC BY license, for self-direc
       <td>Conceptual</td>
       <td>Sara El-Gebali*, Chris Erdmann, Liz Stokes, Kristina Hettne (looking for Maintainers)</td>
    </tr>
-   <tr>
-      <td>XML</td>
-      <td><a href="https://librarycarpentry.org/lc-xml/" target="_blank" class="icon-browser" title="Website for the XML lesson"></a></td>
-      <td><a href="https://github.com/librarycarpentry/lc-xml/" target="_blank" class="icon-github" title="Repository for XML lesson"></a></td>
-      <td><a href="https://librarycarpentry.org/lc-xml/reference.html" target="_blank" class="icon-eye" title="Reference for XML lesson"></a></td>
-      <td><a href="https://librarycarpentry.org/lc-xml/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for XML lesson"></a></td>
-      <td>Conceptual</td>
-      <td>Phil Reed (looking for Maintainers)</td>
-   </tr>
 </table>
 <p>In addition, lessons on <a href="https://github.com/LibraryCarpentry/lc-dig-pres">Digital Preservation</a> and <a href="https://github.com/LibraryCarpentry/lc-tdm">Text and Data Mining</a> are being discussed.</p>
 <hr />


### PR DESCRIPTION
The XML lesson has now been transferred into the Incubator, and is looking for a new owner. This PR removes the lesson from the listing at https://librarycarpentry.org/lessons/