### PR TITLE
Moved MarcEdit lesson to Alpha

### DIFF
--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -147,6 +147,15 @@ Lesson materials are all available online, under a CC BY license, for self-direc
       <td> Tim Dennis, Stéphane Guillou, Clarke Iakovakis*</td>
    </tr>
    <tr>
+      <td>MarcEdit</td>
+      <td><a href="http://librarycarpentry.org/lc-marcedit/" target="_blank" class="icon-browser" title="Website for MarcEdit lesson"></a></td>
+      <td><a href="https://github.com/LibraryCarpentry/lc-marcedit" target="_blank" class="icon-github" title="Repository for MarcEdit lesson"></a></td>
+      <td><a href="http://librarycarpentry.org/lc-marcedit/reference.html" target="_blank" class="icon-eye" title="Reference for MarcEdit lesson"></a></td>
+      <td><a href="http://librarycarpentry.org/lc-marcedit/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for MarcEdit lesson"></a></td>
+      <td>Alpha</td>
+      <td>Jennifer Eustis*, Abigail Sparling*, Owen Stephens (looking for Maintainers)</td>
+   </tr>
+   <tr>
       <td>Intro to AI for GLAM</td>
       <td><a href="https://carpentries-incubator.github.io/machine-learning-librarians-archivists/" target="_blank" class="icon-browser" title="Website for the Introduction to R lesson"></a></td>
       <td><a href="https://github.com/carpentries-incubator/machine-learning-librarians-archivists" target="_blank" class="icon-github" title="Repository for Introduction to R lesson"></a></td>
@@ -219,15 +228,6 @@ Lesson materials are all available online, under a CC BY license, for self-direc
       <th>Instructor Notes</th>
       <th>Status</th>
       <th>Maintainer(s)</th>
-   </tr>
-   <tr>
-      <td>MarcEdit</td>
-      <td><a href="http://librarycarpentry.org/lc-marcedit/" target="_blank" class="icon-browser" title="Website for MarcEdit lesson"></a></td>
-      <td><a href="https://github.com/LibraryCarpentry/lc-marcedit" target="_blank" class="icon-github" title="Repository for MarcEdit lesson"></a></td>
-      <td><a href="http://librarycarpentry.org/lc-marcedit/reference.html" target="_blank" class="icon-eye" title="Reference for MarcEdit lesson"></a></td>
-      <td><a href="http://librarycarpentry.org/lc-marcedit/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for MarcEdit lesson"></a></td>
-      <td>Conceptual</td>
-      <td>Owen Stephens*, Jennifer Eustis, Abigail Sparling (looking for Maintainers)</td>
    </tr>
    <tr>
       <td>Wikidata</td>


### PR DESCRIPTION
Moved our MarcEdit lesson out of conceptual to Alpha as it is under active development and almost complete.

This is related to [issue](https://github.com/carpentries-incubator/proposals/issues/157) in the Incubator. We are looking for community feedback and review.
