### PR TITLE
Fix search form label

### DIFF
--- a/_includes/_google_search.html
+++ b/_includes/_google_search.html
@@ -10,7 +10,7 @@
 </script>
 
 <form id="search" onsubmit="google_search(); return false;">
-        <label for="Search">What are you looking for?</label>
+        <label for="google-search">What are you looking for?</label>
 	<input type="text" id="google-search" placeholder="{{ site.data.language.enter_search_term }}">
 </form>
 <noscript>


### PR DESCRIPTION
On the search page, the search form input is not correctly associated with the label. This is an accessibility issue as it means that a screenreader will not announce the label for the search field. This fixes this so the label is pointing to the correct element.