### PR TITLE
Replace LC Twitter with Mastodon

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -58,8 +58,8 @@
     url: "https://gitter.im/LibraryCarpentry/Lobby"
   - title: "Listserv"
     url: "https://carpentries.topicbox.com/groups/discuss-library-carpentry"
-  - title: "Twitter"
-    url: "https://twitter.com/LibCarpentry"
+  - title: "Mastodon"
+    url: "https://hachyderm.io/@thecarpentries"
   - title: "GitHub"
     url: "https://github.com/LibraryCarpentry"
 

--- a/_data/socialmedia.yml
+++ b/_data/socialmedia.yml
@@ -3,10 +3,10 @@
   class: fa-github
   title: "Library Carpentry GitHub"
 
-- name: Twitter
-  url: https://twitter.com/libcarpentry
-  class: fa-twitter
-  title: "Library Carpentry Twitter"
+- name: Mastodon
+  url: https://hachyderm.io/@thecarpentries
+  class: fa-mastodon
+  title: "The Carpentries on Mastodon"
 
 - name: Connect
   url: https://librarycarpentry.org/contact/

--- a/_includes/_head.html
+++ b/_includes/_head.html
@@ -94,15 +94,15 @@
 	{% if site.socialmedia.facebook %}<meta property="article:author" content="https://www.facebook.com/{{ site.socialmedia.facebook }}">{% endif %}
 
 
-	{% if site.socialmedia.twitter %}
 	<!-- Twitter -->
 	<meta name="twitter:card" content="summary">
+	{% if site.socialmedia.twitter %}
 	<meta name="twitter:site" content="{{ site.socialmedia.twitter }}">
 	<meta name="twitter:creator" content="{{ site.socialmedia.twitter }}">
+	{% endif %}
 	<meta name="twitter:title" content="{{ title }}">
 	<meta name="twitter:description" content="{{ description }}">
 	{% if page.image.title %}<meta name="twitter:image" content="{{ site.urlimg }}{{ page.image.title }}">{% endif %}
-	{% endif %}
 
 	<link type="text/plain" rel="author" href="{{ url}}/humans.txt">
 

--- a/pages/contact.md
+++ b/pages/contact.md
@@ -10,7 +10,7 @@ There are several ways to get in touch.
 
 * [The Carpentries Slack Channel](http://slack-invite.carpentries.org/). Sign up to The Carpentries Slack, add the **#libraries** channel, chat with Library Carpentry community members via our primary chatroom, and get quicker responses.
 
-* [Library Carpentry is on Twitter](https://twitter.com/LibCarpentry). Follow us, learn about what community members are doing, and get updates.
+* [The Carpentries is on Mastodon](https://hachyderm.io/@thecarpentries). Follow us, learn about what community members are doing, and get updates.
 
 * [Library Carpentry Blog Posts](https://librarycarpentry.org/blog/): Where we post Library Carpentry stories from the community and updates from our governance groups.
 

--- a/pages/pages-root-folder/index.md
+++ b/pages/pages-root-folder/index.md
@@ -21,7 +21,7 @@ widget3:
   title: "Get involved"
   url: '/get_involved/'
   icon: 'fas fa-comment-dots'
-  text: 'See all the <a href="contact/">ways you can engage</a> and <a href="get_involved/">get involved</a> with Library Carpentry. Follow us on <a href="https://twitter.com/libcarpentry/">Twitter</a>.'
+  text: 'See all the <a href="contact/">ways you can engage</a> and <a href="get_involved/">get involved</a> with Library Carpentry. Follow us on <a href="https://hachyderm.io/@thecarpentries">Mastodon</a>.'
 #
 # Use the call for action to show a button on the frontpage
 #


### PR DESCRIPTION
Removes the LC Twitter from the website, and replaces it with our unified Mastodon link.