### PR TITLE
update FontAwesome to a version with mastodon logo

### DIFF
--- a/_includes/_head.html
+++ b/_includes/_head.html
@@ -119,7 +119,7 @@
 	{% endunless %}
 
 	<!-- Adding Font Awesome -->
-	<script defer src="https://use.fontawesome.com/releases/v5.0.9/js/all.js" integrity="sha384-8iPTk2s/jMVj81dnzb/iFR2sdA7u06vHJyyLlAd4snFpCl/SnyUjRrbdJsw1pGIl" crossorigin="anonymous"></script>
+	<script defer src="https://use.fontawesome.com/releases/v5.0.11/js/all.js" integrity="sha384-8iPTk2s/jMVj81dnzb/iFR2sdA7u06vHJyyLlAd4snFpCl/SnyUjRrbdJsw1pGIl" crossorigin="anonymous"></script>
 
 <!-- CSS overrides -->
 	<link rel="stylesheet" type="text/css" href="{{ url }}/assets/css/extras.css">


### PR DESCRIPTION
The currently used version (v5.0.9) doesn't have the Mastodon logo. For maximum compatibility, I bumped to the closest version which does have it (v5.0.11)