### PR TITLE
Switch to FontAwesome kit

### DIFF
--- a/_includes/_head.html
+++ b/_includes/_head.html
@@ -119,7 +119,7 @@
 	{% endunless %}
 
 	<!-- Adding Font Awesome -->
-	<script defer src="https://use.fontawesome.com/releases/v5.0.9/js/all.js" integrity="sha384-8iPTk2s/jMVj81dnzb/iFR2sdA7u06vHJyyLlAd4snFpCl/SnyUjRrbdJsw1pGIl" crossorigin="anonymous"></script>
+	<script src="https://kit.fontawesome.com/3a6fac633d.js" crossorigin="anonymous"></script>
 
 <!-- CSS overrides -->
 	<link rel="stylesheet" type="text/css" href="{{ url }}/assets/css/extras.css">


### PR DESCRIPTION
This matches what we use on the SWC and DC sites, and includes a more recent version of FontAwesome.