### PR TITLE
remove inactive Maintainers

### DIFF
--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -42,7 +42,7 @@ Lesson materials are all available online, under a CC BY license, for self-direc
       <td><a href="https://librarycarpentry.org/lc-overview/reference.html" target="_blank" class="icon-eye" title="Reference for Workshop Overview"></a></td>
       <td><a href="https://librarycarpentry.org/lc-overview/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for Workshop Overview"></a></td>
       <td>Stable</td>
-      <td>Jesse Johnston, Rayvn Manuel, Elizabeth McAulay</td>
+      <td>Jesse Johnston, Elizabeth McAulay</td>
    </tr>
    <tr>
       <td>Introduction to Working with Data (Regular Expressions)</td>
@@ -60,7 +60,7 @@ Lesson materials are all available online, under a CC BY license, for self-direc
       <td><a href="https://librarycarpentry.org/lc-shell/reference.html" target="_blank" class="icon-eye" title="Reference for UNIX Shell lesson"></a></td>
       <td><a href="https://librarycarpentry.org/lc-shell/instructor/instructor-notes" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for UNIX Shell lesson"></a></td>
       <td>Stable</td>
-      <td>Jamie Jamison, Kaitlin Newson, Anna Oates</td>
+      <td>Jamie Jamison, Kaitlin Newson</td>
    </tr>
    <tr>
       <td>OpenRefine</td>
@@ -78,7 +78,7 @@ Lesson materials are all available online, under a CC BY license, for self-direc
       <td><a href="https://librarycarpentry.org/lc-git/reference.html" target="_blank" class="icon-eye" title="Reference for Introduction to Git lesson"></a></td>
       <td><a href="https://librarycarpentry.org/lc-git/instructor/instructor-notes" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for Introduction to Git lesson"></a></td>
       <td>Stable</td>
-      <td>Rayvn Manuel, Elizabeth McAulay</td>
+      <td>Elizabeth McAulay</td>
    </tr>
 </table>
 <hr />
@@ -117,7 +117,7 @@ Lesson materials are all available online, under a CC BY license, for self-direc
       <td><a href="https://librarycarpentry.org/lc-spreadsheets/reference.html" target="_blank" class="icon-eye" title="Reference for Tidy Data lesson"></a></td>
       <td><a href="https://librarycarpentry.org/lc-spreadsheets/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for Tidy Data lesson"></a></td>
       <td>Stable</td>
-      <td>Barulaganye Hulela, Jesse Johnston, Tim Dennis</td>
+      <td>Jesse Johnston</td>
    </tr>
    <tr>
       <td>Introduction to Python</td>
@@ -236,7 +236,7 @@ Lesson materials are all available online, under a CC BY license, for self-direc
       <td><a href="https://librarycarpentry.org/lc-wikidata/reference.html" target="_blank" class="icon-eye" title="Reference for Wikidata lesson"></a></td>
       <td><a href="https://librarycarpentry.org/lc-wikidata/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for Wikidata lesson"></a></td>
       <td>Conceptual</td>
-      <td>Konrad Förstner*, Rabea Müller </td>
+      <td>Rabea Müller </td>
    </tr>
    <tr>
       <td>FAIR Data & Software</td>


### PR DESCRIPTION
Remove Maintainers who did not respond to issues related to Workbench transition.

https://github.com/LibraryCarpentry/lc-data-intro-archives/issues/30
https://github.com/LibraryCarpentry/lc-git/issues/137
https://github.com/LibraryCarpentry/lc-marcedit/issues/62
https://github.com/LibraryCarpentry/lc-shell/issues/226
https://github.com/LibraryCarpentry/lc-spreadsheets/issues/134
https://github.com/LibraryCarpentry/lc-wikidata/issues/43

Affected Maintainers can re-establish access by contacting [curriculum@carpentries.org](mailto:curriculum@carpentries.org) after re-cloning their lesson repo(s) on their local machine. 