### PR TITLE
redirect workshop content to carpentries.org

### DIFF
--- a/pages/get_involved.html
+++ b/pages/get_involved.html
@@ -8,9 +8,7 @@ title: "Get Involved"
 
 <p>
   <ul>
-    <li><a href="#Attend">Attend a workshop</a></li>
-    <li><a href="#Volunteer">Volunteer to help with a workshop</a></li>
-    <li><a href="#Host">Host a workshop</a></li>
+    <li><a href="https://carpentries.org/workshops/">Host a workshop</a></li>
     <li><a href="https://carpentries.org/become-instructor/">Apply to be an instructor</a></li>
     <li><a href="https://carpentries.org/involved-lessons/">Contribute to our lessons</a></li>
     <li><a href="#Become">Become a member</a></li>
@@ -19,26 +17,6 @@ title: "Get Involved"
   </ul>
 </p>
 
-<a name="Attend"></a>
-<h3>Attend a workshop</h3>
-<p>Browse our <a href="/upcoming_workshops/">Upcoming Library Carpentry Workshops</a> to see if there is an opportunity near you. Also see <a href="https://carpentries.org/upcoming_workshops/">The Carpentries Upcoming Workshops</a> which include workshops from Software Carpentry, Data Carpentry, and Library Carpentry. Sometimes our workshops appear to be only available to organizations but don’t let that stop you. It doesn’t hurt to ask the instructors if there is space available. We often mention upcoming workshops in our various communication channels, but if you are interested in attending a workshop in your area and don’t see one, don’t hesitate to reach out to these communication channels to see if there is an opportunity that hasn’t been announced yet.</p>
-
-<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr"><a href="https://twitter.com/LibCarpentry?ref_src=twsrc%5Etfw">@LibCarpentry</a> Workshop commencing <a href="https://twitter.com/eResAfrica?ref_src=twsrc%5Etfw">@eResAfrica</a> <a href="https://twitter.com/hashtag/ERA2017?src=hash&amp;ref_src=twsrc%5Etfw">#ERA2017</a> a lot of enthusiasm with the jargon busting excersize! <a href="https://t.co/qYAMW3m1cs">pic.twitter.com/qYAMW3m1cs</a></p>&mdash; Juan Steyn (@JuanSteyn) <a href="https://twitter.com/JuanSteyn/status/860405598462128128?ref_src=twsrc%5Etfw">May 5, 2017</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script> 
-
-<a name="Volunteer"></a>
-<h3>Volunteer to help with a workshop</h3>
-<p>Instructors always need help. In our workshops, whenever a learner needs help, they place a red sticky on their laptop or raise their hand. Helpers assist learners work through any challenges or questions they may have. If you are familiar with the lesson material being taught, you can reach out to the instructors to see if you can join the workshop and assist. You don’t have to be familiar with all the lesson material, even just one lesson/tool/approach is fine. To find upcoming workshops being held near you, you can browse the <a href="https://carpentries.org/upcoming_workshops/">Upcoming Carpentries Workshops</a> . Alternatively, you don’t necessarily need to be familiar with the material and can inquire with the instructors whether you can observe a workshop instead.</p>
-
-<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr"><a href="https://twitter.com/hashtag/CarpentryConnectJHB?src=hash&amp;ref_src=twsrc%5Etfw">#CarpentryConnectJHB</a> has started! 3 workshops running over next 3 days: <a href="https://twitter.com/datacarpentry?ref_src=twsrc%5Etfw">@datacarpentry</a> for Social Sciences with <a href="https://twitter.com/hashtag/Python?src=hash&amp;ref_src=twsrc%5Etfw">#Python</a>; <a href="https://twitter.com/swcarpentry?ref_src=twsrc%5Etfw">@swcarpentry</a> with <a href="https://twitter.com/hashtag/rstats?src=hash&amp;ref_src=twsrc%5Etfw">#rstats</a>, shell, git; <a href="https://twitter.com/LibCarpentry?ref_src=twsrc%5Etfw">@LibCarpentry</a> with <a href="https://twitter.com/OpenRefine?ref_src=twsrc%5Etfw">@OpenRefine</a> and shell. 20+ instructors &amp; helpers. 80+ participants from South African universities <a href="https://t.co/gjzdTKk12L">pic.twitter.com/gjzdTKk12L</a></p>&mdash; Anelda van der Walt (@aneldavdw) <a href="https://twitter.com/aneldavdw/status/1036548140634128384?ref_src=twsrc%5Etfw">September 3, 2018</a></blockquote>
-<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-
-<a name="Host"></a>
-<h3>Host a workshop</h3>
-<p>Sometimes the best way to understand what a Library Carpentry workshop is like is to host a workshop yourself. Hosting a workshop allows you to see what it takes to organize a workshop, to see the discussions between instructors to determine the appropriate lesson material for your audience, the steps involved in creating a welcoming environment, and more. You can read more about hosting workshops in <a href="https://docs.carpentries.org">The Carpentries Handbook</a>.</p>
-
-<p>If you are considering hosting a workshop, we will work to keep your costs to a minimum. The workshop administration fee is $2,500, and the host site is responsible for instructor travel expenses. We suggest that you estimate $2,500 for the travel, food and accommodations of two instructors, however, we will work to find instructors as local as possible to reduce travel costs. Our <a href="https://carpentries.org/instructors">network of instructors</a> is increasing and more instructors from the overall Carpentries will be able to teach Library Carpentry as we integrate our instructor training material. It is important to note that you must have at least one certified volunteer instructor leading your workshop for it to be listed as an official Library Carpentry and Carpentries workshop. Additional costs to consider include the workshop space and catering. Regarding other resources, laptops and/or desktop computers are often needed as well as helpers from your local community that are familiar with the tools and approaches you will cover in your workshop. Some hosts use Eventbrite to minimize costs and ask for registration. For more information, see the <a href="https://docs.carpentries.org/topic_folders/hosts_instructors/index.html">Teaching and Hosting</a> section of The Carpentries Handbook.</p>
-
-<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Some photos from our <a href="https://twitter.com/LibCarpentry?ref_src=twsrc%5Etfw">@LibCarpentry</a> workshop held last Friday. Thanks to <a href="https://twitter.com/davidfkane?ref_src=twsrc%5Etfw">@davidfkane</a> for running the show and great to get such positive feedback from the participants. Hope to see you all on the 5th Dec for our seminar <a href="https://t.co/HNcFVFdvJj">https://t.co/HNcFVFdvJj</a> <a href="https://twitter.com/hashtag/LIRHEAnet?src=hash&amp;ref_src=twsrc%5Etfw">#LIRHEAnet</a> <a href="https://t.co/X1CE1w3OhK">pic.twitter.com/X1CE1w3OhK</a></p>&mdash; LIR HEAnet (@LIRHEAnet) <a href="https://twitter.com/LIRHEAnet/status/1036615532563165190?ref_src=twsrc%5Etfw">September 3, 2018</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script> 
 
 <a name="Become"></a>
 <h3>Become a member</h3>  

--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -20,7 +20,7 @@ Lesson materials are all available online, under a CC BY license, for self-direc
 
 <h3 id="-core-curriculum"><a id="core-curriculum"></a>Our Core Curriculum</h3>
 
-<p>Our Core Curriculum consists of the lessons in the table below. These have been taught many times, and have been further refined after instructor and learner feedback. For more information regarding core lessons and workshops, see <a href="/workshops/">Our Workshops</a> and the <a href="/lc-overview/">Workshop Overview</a>.</p>
+<p>Our Core Curriculum consists of the lessons in the table below. These have been taught many times, and have been further refined after instructor and learner feedback. For more information regarding core lessons and workshops across The Carpentries, visit <a href="https://carpentries.org/workshops/">The Carpentries workshops page</a>.</p>
 
 <p>The lessons introduce terms, phrases, and concepts in software development and data science, how to best work with data structures, and use regular expressions in finding and matching data. We introduce the Unix-style command line interface, and teach basic shell navigation, as well as the use of loops and pipes for linking shell commands. We also introduce grep for searching and subsetting data across files. Exercises cover the counting and mining of data. In addition, we cover working with OpenRefine to transform and clean data, and the benefits of working collaboratively via Git/GitHub and using version control to track your work.</p>
 

--- a/pages/workshops.md
+++ b/pages/workshops.md
@@ -2,21 +2,5 @@
 layout: page-fullwidth
 title: "Our Workshops"
 permalink: /workshops/
+redirect_to: https://carpentries.org/workshops/
 ---
-
-Library Carpentry develops and teaches interactive, hands-on workshops for learning core software and data skills of relevance to those in library roles. Our workshops are domain-agnostic though datasets used will be familiar to library staff. 
-
-Library Carpentry workshops are in-person events and are taught by at least one volunteer certified Instructor. Our Instructors are [trained in pedagogy](http://carpentries.github.io/instructor-training/) with a focus on creating a motivating and engaging learning environment. 
-
-An official Library Carpentry workshop must include three to four of our [core lessons](/lessons/). All workshops that are reported to Library Carpentry are listed in the ‘Upcoming Workshops’ section of this site and range from 1-day to multi-day. See _[What constitutes a Library Carpentry workshop?](https://librarycarpentry.org/blog/2018/08/what-is-a-workshop/)_ and _[Seventy-One Workshops... and Counting](https://librarycarpentry.org/blog/2018/08/seventy-one-and-counting/)_ for further information. All participants must be prepared to observe The Carpentries [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html) in workshops. Library Carpentry lesson materials are freely available under a permissive open license and available for the wider community to use for Library Carpentry-based workshops.
-
-Prior to and following each workshop, instructors have surveys available to them to assess participants' understanding of data and software tools and approaches taught. Our surveys align with The Carpentries surveys and programmatic/learner assessments. Library Carpentry pre and post workshop surveys are available via the Carpentries [workshop template](https://github.com/carpentries/workshop-template).
-
-Our lesson materials are collaboratively developed by our volunteer community. All of our lessons are open source, and are hosted on [GitHub](https://github.com/librarycarpentry). 
-
-To request a workshop at your institution or to register your Self-Organised workshop, visit the [The Carpentries](https://amy.carpentries.org/forms/workshop/) workshop request page. Indicate in the form that you are interested in hosting a Library Carpentry workshop. If you're interested other ways Library Carpentry lessons can be used at your site, please contact [team@carpentries.org](mailto:team@carpentries.org). Please note, our workshop workflow is undergoing updates (see [Introducing updated Workshop Request Forms and More](https://carpentries.org/blog/2019/09/Workshop-request-forms-and-more/)). 
-
-The Carpentries team of [Regional Coordinators](https://carpentries.org/regionalcoordinators/) supports workshop activity in various global regions. These teams can connect you with regional communities.
-
-If you're running a workshop, check out our guides for [teaching and hosting](https://docs.carpentries.org/topic_folders/hosts_instructors/index.html) a workshop. 
-  


### PR DESCRIPTION
Remove content from LC website about workshop operations.  Redirect all such content to https://carpentries.org/workshops/.

