### PR TITLE
retire lc overview lesson

### DIFF
--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -36,13 +36,13 @@ Lesson materials are all available online, under a CC BY license, for self-direc
       <th>Maintainer(s)</th>
    </tr>
    <tr>
-      <td>Workshop Overview</td>
-      <td><a href="https://librarycarpentry.org/lc-overview/" target="_blank" class="icon-browser" title="Website for Workshop Overview lesson"></a></td>
-      <td><a href="https://github.com/librarycarpentry/lc-overview" target="_blank" class="icon-github" title="Repository for Workshop Overview lesson"></a></td>
-      <td><a href="https://librarycarpentry.org/lc-overview/reference.html" target="_blank" class="icon-eye" title="Reference for Workshop Overview"></a></td>
-      <td><a href="https://librarycarpentry.org/lc-overview/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for Workshop Overview"></a></td>
+      <td>Tidy Data</td>
+      <td><a href="https://librarycarpentry.org/lc-spreadsheets/" target="_blank" class="icon-browser" title="Website for Tidy Data lesson"></a></td>
+      <td><a href="https://github.com/librarycarpentry/lc-spreadsheets/" target="_blank" class="icon-github" title="Repository for Tidy Data lesson"></a></td>
+      <td><a href="https://librarycarpentry.org/lc-spreadsheets/reference.html" target="_blank" class="icon-eye" title="Reference for Tidy Data lesson"></a></td>
+      <td><a href="https://librarycarpentry.org/lc-spreadsheets/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for Tidy Data lesson"></a></td>
       <td>Stable</td>
-      <td>Jesse Johnston, Elizabeth McAulay</td>
+      <td>Jesse Johnston</td>
    </tr>
    <tr>
       <td>Introduction to Working with Data (Regular Expressions)</td>
@@ -110,15 +110,7 @@ Lesson materials are all available online, under a CC BY license, for self-direc
       <td>Stable</td>
       <td>Julika Mimkes</td>
    </tr>
-   <tr>
-      <td>Tidy Data</td>
-      <td><a href="https://librarycarpentry.org/lc-spreadsheets/" target="_blank" class="icon-browser" title="Website for Tidy Data lesson"></a></td>
-      <td><a href="https://github.com/librarycarpentry/lc-spreadsheets/" target="_blank" class="icon-github" title="Repository for Tidy Data lesson"></a></td>
-      <td><a href="https://librarycarpentry.org/lc-spreadsheets/reference.html" target="_blank" class="icon-eye" title="Reference for Tidy Data lesson"></a></td>
-      <td><a href="https://librarycarpentry.org/lc-spreadsheets/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for Tidy Data lesson"></a></td>
-      <td>Stable</td>
-      <td>Jesse Johnston</td>
-   </tr>
+   
    <tr>
       <td>Introduction to Python</td>
       <td><a href="https://librarycarpentry.org/lc-python-intro/" target="_blank" class="icon-browser" title="Website for the Introduction to Python lesson"></a></td>
@@ -208,6 +200,15 @@ Lesson materials are all available online, under a CC BY license, for self-direc
       <td><a href="https://carpentries-incubator.github.io/lc-webscraping/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for Webscraping lesson"></a></td>
       <td>Retired (was alpha)</td>
       <td>Thomas Guignard</td>
+   </tr>
+   <tr>
+      <td>Workshop Overview</td>
+      <td><a href="https://librarycarpentry.org/lc-overview/" target="_blank" class="icon-browser" title="Website for Workshop Overview lesson"></a></td>
+      <td><a href="https://github.com/librarycarpentry/lc-overview" target="_blank" class="icon-github" title="Repository for Workshop Overview lesson"></a></td>
+      <td><a href="https://librarycarpentry.org/lc-overview/reference.html" target="_blank" class="icon-eye" title="Reference for Workshop Overview"></a></td>
+      <td><a href="https://librarycarpentry.org/lc-overview/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for Workshop Overview"></a></td>
+      <td>Stable</td>
+      <td>Jesse Johnston, Elizabeth McAulay</td>
    </tr>
 </table>
 <hr />

--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -207,7 +207,7 @@ Lesson materials are all available online, under a CC BY license, for self-direc
       <td><a href="https://github.com/librarycarpentry/lc-overview" target="_blank" class="icon-github" title="Repository for Workshop Overview lesson"></a></td>
       <td><a href="https://librarycarpentry.org/lc-overview/reference.html" target="_blank" class="icon-eye" title="Reference for Workshop Overview"></a></td>
       <td><a href="https://librarycarpentry.org/lc-overview/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for Workshop Overview"></a></td>
-      <td>Stable</td>
+      <td>Retired (was stable)</td>
       <td>Jesse Johnston, Elizabeth McAulay</td>
    </tr>
 </table>


### PR DESCRIPTION
- move LC Overview under Retired Curriculum
- move Tidy Data to Core Curriculum

As recommended by LC Curriculum Advisory Committee. 

See a number of issues in the LC Overview lesson for context: 

- [56](https://github.com/LibraryCarpentry/lc-overview/issues/56)
- [57](https://github.com/LibraryCarpentry/lc-overview/issues/57)
- [58](https://github.com/LibraryCarpentry/lc-overview/issues/58)
- [59](https://github.com/LibraryCarpentry/lc-overview/issues/59)
- [66](https://github.com/LibraryCarpentry/lc-overview/issues/66)
