### PR TITLE
Update lc lessons page

### DIFF
--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -88,8 +88,16 @@ permalink: /lessons/
       <td><a href="https://carpentries-incubator.github.io/machine-learning-librarians-archivists/" target="_blank" class="icon-browser" title="Website for the Intro to AI for GLAM"></a></td>
       <td><a href="https://github.com/carpentries-incubator/machine-learning-librarians-archivists" target="_blank" class="icon-github" title="Repository for Intro to AI for GLAM"></a></td>
       <td>Beta</td>
-      <td>1 hour</td>
+      <td>2 to 3 hours</td>
       <td>Mark Bell, Nora McGregor, Daniel van Strien, Mike Trizna </td>
+   </tr>
+   <tr>
+      <td>Introducing Computational Thinking</td>
+      <td><a href="https://librarycarpentry.org/lc-computational-thinking/" target="_blank" class="icon-browser" title="Website for Introducing Computational Thinking lesson"></a></td>
+      <td><a href="https://github.com/LibraryCarpentry/lc-computational-thinking" target="_blank" class="icon-github" title="Repository for Introducing Computational Thinking lesson"></a></td>
+      <td>Alpha</td>
+      <td>3 to 4 hours</td>
+      <td>Tim Dennis, Belinda Weaver (looking for Maintainers)</td>
    </tr>
    <tr>
       <td>Introduction to Data for Archivists</td>
@@ -116,7 +124,7 @@ permalink: /lessons/
       <td>Jia Qi Beh, Tim Dennis</td>
    </tr>
        <tr>
-      <td>Introduction to Regular Expressions</td>
+      <td>Introduction to Working with Data (Regular Expressions)</td>
       <td><a href="https://librarycarpentry.org/lc-data-intro/" target="_blank" class="icon-browser" title="Website for Introduction to Data lesson"></a></td>
       <td><a href="https://github.com/librarycarpentry/lc-data-intro/" target="_blank" class="icon-github" title="Repository for Introduction to Data lesson"></a></td>
       <td>Stable</td>
@@ -127,7 +135,7 @@ permalink: /lessons/
       <td>MarcEdit</td>
       <td><a href="http://librarycarpentry.org/lc-marcedit/" target="_blank" class="icon-browser" title="Website for MarcEdit lesson"></a></td>
       <td><a href="https://github.com/LibraryCarpentry/lc-marcedit" target="_blank" class="icon-github" title="Repository for MarcEdit lesson"></a></td>
-      <td>Alpha</td>
+      <td>Beta</td>
       <td>3 to 4 hours</td>
       <td>Jennifer Eustis*, Abigail Sparling*, Owen Stephens (looking for Maintainers)</td>
    </tr>

--- a/pages/lessons.html
+++ b/pages/lessons.html
@@ -4,25 +4,12 @@ title: "Our lessons"
 permalink: /lessons/
 ---
 
-<h3 id="-core-objectives"><a id="core-objectives"></a>Our Core Objectives</h3>
-
-<p>Library Carpentry workshops teach people working in library- and information-related roles how to:</p>
-<ul>
-   <li>Cut through the jargon terms and phrases of software development and data science and apply concepts from these fields in library tasks;</li>
-   <li>Identify and use best practices in data structures;</li>
-   <li>Learn how to programmatically transform and map data from one form to another;</li>
-   <li>Work effectively with researchers, IT, and systems colleagues;</li>
-   <li>Automate repetitive, error prone tasks.</li>
-</ul>
-
-Lesson materials are all available online, under a CC BY license, for self-directed study or for adaptation and re-use (as "Carpentries-based" training).
-<hr />
 
 <h3 id="-core-curriculum"><a id="core-curriculum"></a>Our Core Curriculum</h3>
 
-<p>Our Core Curriculum consists of the lessons in the table below. These have been taught many times, and have been further refined after instructor and learner feedback. For more information regarding core lessons and workshops across The Carpentries, visit <a href="https://carpentries.org/workshops/">The Carpentries workshops page</a>.</p>
+<p>Our core curriculum lessons have been taught many times, and have been further refined based on instructor and learner feedback. This curriculum is designed for learners coming from a wide variety of library and information-related backgrounds.</p>
 
-<p>The lessons introduce terms, phrases, and concepts in software development and data science, how to best work with data structures, and use regular expressions in finding and matching data. We introduce the Unix-style command line interface, and teach basic shell navigation, as well as the use of loops and pipes for linking shell commands. We also introduce grep for searching and subsetting data across files. Exercises cover the counting and mining of data. In addition, we cover working with OpenRefine to transform and clean data, and the benefits of working collaboratively via Git/GitHub and using version control to track your work.</p>
+<p>The length of lessons offered below is an estimated range. The actual time to deliver a lesson can vary widely depending on how many exercies are offered, the backgrounds of learners, and more.</p>
 
 <h4 id="lessons">Lessons</h4>
 <table class="table table-striped">
@@ -30,54 +17,41 @@ Lesson materials are all available online, under a CC BY license, for self-direc
       <th>Lesson</th>
       <th>Site</th>
       <th>Repository</th>
-      <th>Reference</th>
-      <th>Instructor Notes</th>
       <th>Status</th>
+      <th>Length</th>
       <th>Maintainer(s)</th>
    </tr>
    <tr>
       <td>Tidy Data</td>
       <td><a href="https://librarycarpentry.org/lc-spreadsheets/" target="_blank" class="icon-browser" title="Website for Tidy Data lesson"></a></td>
       <td><a href="https://github.com/librarycarpentry/lc-spreadsheets/" target="_blank" class="icon-github" title="Repository for Tidy Data lesson"></a></td>
-      <td><a href="https://librarycarpentry.org/lc-spreadsheets/reference.html" target="_blank" class="icon-eye" title="Reference for Tidy Data lesson"></a></td>
-      <td><a href="https://librarycarpentry.org/lc-spreadsheets/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for Tidy Data lesson"></a></td>
       <td>Stable</td>
+      <td>2 to 3 hours</td>
       <td>Marco Chiapello, Jesse Johnston</td>
    </tr>
-   <tr>
-      <td>Introduction to Working with Data (Regular Expressions)</td>
-      <td><a href="https://librarycarpentry.org/lc-data-intro/" target="_blank" class="icon-browser" title="Website for Introduction to Data lesson"></a></td>
-      <td><a href="https://github.com/librarycarpentry/lc-data-intro/" target="_blank" class="icon-github" title="Repository for Introduction to Data lesson"></a></td>
-      <td><a href="https://librarycarpentry.org/lc-data-intro/reference.html" target="_blank" class="icon-eye" title="Reference for Introduction to Data lesson"></a></td>
-      <td><a href="https://librarycarpentry.org/lc-data-intro/instructor/instructor-notes" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for Introduction to Data lesson"></a></td>
-      <td>Stable</td>
-      <td>Freddy Chia, Kevin French</td>
-   </tr>
+
    <tr>
       <td>The UNIX Shell</td>
       <td><a href="https://librarycarpentry.org/lc-shell/" target="_blank" class="icon-browser" title="Website for the UNIX Shell lesson"></a></td>
       <td><a href="https://github.com/librarycarpentry/lc-shell/" target="_blank" class="icon-github" title="Repository for the UNIX Shell lesson"></a></td>
-      <td><a href="https://librarycarpentry.org/lc-shell/reference.html" target="_blank" class="icon-eye" title="Reference for UNIX Shell lesson"></a></td>
-      <td><a href="https://librarycarpentry.org/lc-shell/instructor/instructor-notes" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for UNIX Shell lesson"></a></td>
-      <td>Stable</td>
+       <td>Stable</td>
+       <td>3 to 4 hours</td>
       <td>Jamie Jamison, Kaitlin Newson</td>
    </tr>
    <tr>
       <td>OpenRefine</td>
       <td><a href="https://librarycarpentry.org/lc-open-refine/" target="_blank" class="icon-browser" title="Website for OpenRefine lesson"></a></td>
       <td><a href="https://github.com/librarycarpentry/lc-open-refine/" target="_blank" class="icon-github" title="Repository for OpenRefine lesson"></a></td>
-      <td><a href="https://librarycarpentry.org/lc-open-refine/reference.html" target="_blank" class="icon-eye" title="Reference for OpenRefine lesson"></a></td>
-      <td><a href="https://librarycarpentry.org/lc-open-refine/instructor/instructor-notes" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for OpenRefine lesson"></a></td>
       <td>Stable</td>
+      <td>3 to 4 hours</td>
       <td>Roman Kuhn, Max Prud'homme, Owen Stephens, Jennifer Stubbs</td>
    </tr>
    <tr>
       <td>Introduction to Git</td>
       <td><a href="https://librarycarpentry.org/lc-git/" target="_blank" class="icon-browser" title="Website for Introduction to Git lesson"></a></td>
       <td><a href="https://github.com/librarycarpentry/lc-git/" target="_blank" class="icon-github" title="Repository for Introduction to Git lesson"></a></td>
-      <td><a href="https://librarycarpentry.org/lc-git/reference.html" target="_blank" class="icon-eye" title="Reference for Introduction to Git lesson"></a></td>
-      <td><a href="https://librarycarpentry.org/lc-git/instructor/instructor-notes" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for Introduction to Git lesson"></a></td>
       <td>Stable</td>
+      <td>2 to 3 hours</td>
       <td>Seth Erickson, Elizabeth McAulay</td>
    </tr>
 </table>
@@ -86,8 +60,9 @@ Lesson materials are all available online, under a CC BY license, for self-direc
 <h3 id="-extended-curriculum"><a id="extended-curriculum"></a>Extended Curriculum</h3>
 
 
-<p>The following Library Carpentry lessons can also be taught in addition to our core curriculum. Some of the lessons have been taught
-   infrequently and still need further work. We would value any feedback on these lessons.</p>
+<p>The following Library Carpentry lessons can be taught in addition to our core curriculum. Feel free to mix and match extended lessons with core lessons, or to teach extended lessons as standalone modules. Be sure to check prerequisites as some lessons require background knowledge.</p>
+
+<p>Please consider the <a href="https://carpentries.github.io/lesson-development-training/19-operations.html#the-lesson-life-cycle">Carpentries lesson life-cycle</a> status listed next to each lesson when considering whether or not to teach any of the lessons below. In general, Stable and Beta lessons are more robust than Alpha and Pre-Alpha (Conceptual) lessons. Alpha and Pre-Alpha lessons may require additional instructor preparation before they're ready to teach.
 
 
 <h4 id="lessons">Lessons</h4>
@@ -96,91 +71,87 @@ Lesson materials are all available online, under a CC BY license, for self-direc
       <th>Lesson</th>
       <th>Site</th>
       <th>Repository</th>
-      <th>Reference</th>
-      <th>Instructor Notes</th>
       <th>Status</th>
+      <th>Length</th>
       <th>Maintainer(s)</th>
    </tr>
-   <tr>
-      <td>SQL</td>
-      <td><a href="https://librarycarpentry.org/lc-sql/" target="_blank" class="icon-browser" title="Website for SQL lesson"></a></td>
-      <td><a href="https://github.com/librarycarpentry/lc-sql/" target="_blank" class="icon-github" title="Repository for SQL lesson"></a></td>
-      <td><a href="https://librarycarpentry.org/lc-sql/reference.html" target="_blank" class="icon-eye" title="Reference for SQL lesson"></a></td>
-      <td><a href="https://librarycarpentry.org/lc-sql/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for SQL lesson"></a></td>
-      <td>Stable</td>
-      <td>Julika Mimkes, Annajiat Alim Rasel</td>
-   </tr>
-   
-   <tr>
-      <td>Introduction to Python</td>
-      <td><a href="https://librarycarpentry.org/lc-python-intro/" target="_blank" class="icon-browser" title="Website for the Introduction to Python lesson"></a></td>
-      <td><a href="https://github.com/librarycarpentry/lc-python-intro/" target="_blank" class="icon-github" title="Repository for Introduction to Python lesson"></a></td>
-      <td><a href="https://librarycarpentry.org/lc-python-intro/reference.html" target="_blank" class="icon-eye" title="Reference for Introduction to Python lesson"></a></td>
-      <td><a href="https://librarycarpentry.org/lc-python-intro/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for Introduction to Python lesson"></a></td>
+    <tr>
+      <td><acronym title="Data Management Plan">DMP</acronym> Course for Librarians</td>
+      <td><a href="http://librarycarpentry.org/lc-dmp101/" target="_blank" class="icon-browser" title="Website for DMP Course for Librarians"></a></td>
+      <td><a href="https://github.com/LibraryCarpentry/lc-dmp101" target="_blank" class="icon-github" title="Repository for DMP Course for Librarians "></a></td>
       <td>Alpha</td>
-      <td>Cody Hennesy, Tim Dennis</td>
+      <td>2 to 3 hours</td>
+      <td>Lena Bohman, Marla Hertz, Daria Orlowska</td>
+    </tr>
+    <tr>
+      <td>Intro to AI for GLAM</td>
+      <td><a href="https://carpentries-incubator.github.io/machine-learning-librarians-archivists/" target="_blank" class="icon-browser" title="Website for the Intro to AI for GLAM"></a></td>
+      <td><a href="https://github.com/carpentries-incubator/machine-learning-librarians-archivists" target="_blank" class="icon-github" title="Repository for Intro to AI for GLAM"></a></td>
+      <td>Beta</td>
+      <td>1 hour</td>
+      <td>Mark Bell, Nora McGregor, Daniel van Strien, Mike Trizna </td>
    </tr>
    <tr>
       <td>Introduction to Data for Archivists</td>
       <td><a href="https://librarycarpentry.org/lc-data-intro-archives/" target="_blank" class="icon-browser" title="Website for Introduction to Data for Archivists lesson"></a></td>
       <td><a href="https://github.com/librarycarpentry/lc-data-intro-archives/" target="_blank" class="icon-github" title="Repository for Introduction to Data for Archivists lesson"></a></td>
-      <td><a href="https://librarycarpentry.org/lc-data-intro-archives/reference.html" target="_blank" class="icon-eye" title="Reference for Introduction to Data for Archivists lesson"></a></td>
-      <td><a href="https://librarycarpentry.org/lc-data-intro-archives/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for Introduction to Data for Archivists lesson"></a></td>
       <td>Alpha</td>
+      <td>3 to 4 hours</td>
       <td>Katherine Koziar*</td>
+   </tr>
+   <tr>
+      <td>Introduction to Python</td>
+      <td><a href="https://librarycarpentry.org/lc-python-intro/" target="_blank" class="icon-browser" title="Website for the Introduction to Python lesson"></a></td>
+      <td><a href="https://github.com/librarycarpentry/lc-python-intro/" target="_blank" class="icon-github" title="Repository for Introduction to Python lesson"></a></td>
+     <td>Beta</td>
+     <td>5 to 7 hours</td>
+      <td>Cody Hennesy*, Tim Dennis</td>
    </tr>
    <tr>
       <td>Introduction to R</td>
       <td><a href="https://librarycarpentry.org/lc-r/" target="_blank" class="icon-browser" title="Website for the Introduction to R lesson"></a></td>
       <td><a href="https://github.com/librarycarpentry/lc-r/" target="_blank" class="icon-github" title="Repository for Introduction to R lesson"></a></td>
-      <td><a href="https://librarycarpentry.org/lc-r/reference.html" target="_blank" class="icon-eye" title="Reference for Introduction to R lesson"></a></td>
-      <td><a href="https://librarycarpentry.org/lc-r/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for Introduction to R lesson"></a></td>
       <td>Alpha</td>
+      <td>5 to 7 hours</td>
       <td>Jia Qi Beh, Tim Dennis</td>
+   </tr>
+       <tr>
+      <td>Introduction to Regular Expressions</td>
+      <td><a href="https://librarycarpentry.org/lc-data-intro/" target="_blank" class="icon-browser" title="Website for Introduction to Data lesson"></a></td>
+      <td><a href="https://github.com/librarycarpentry/lc-data-intro/" target="_blank" class="icon-github" title="Repository for Introduction to Data lesson"></a></td>
+      <td>Stable</td>
+      <td>2 to 3 hours</td>
+      <td>Freddy Chia, Kevin French</td>
    </tr>
    <tr>
       <td>MarcEdit</td>
       <td><a href="http://librarycarpentry.org/lc-marcedit/" target="_blank" class="icon-browser" title="Website for MarcEdit lesson"></a></td>
       <td><a href="https://github.com/LibraryCarpentry/lc-marcedit" target="_blank" class="icon-github" title="Repository for MarcEdit lesson"></a></td>
-      <td><a href="http://librarycarpentry.org/lc-marcedit/reference.html" target="_blank" class="icon-eye" title="Reference for MarcEdit lesson"></a></td>
-      <td><a href="http://librarycarpentry.org/lc-marcedit/guide/" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for MarcEdit lesson"></a></td>
       <td>Alpha</td>
+      <td>3 to 4 hours</td>
       <td>Jennifer Eustis*, Abigail Sparling*, Owen Stephens (looking for Maintainers)</td>
    </tr>
    <tr>
-      <td>Intro to AI for GLAM</td>
-      <td><a href="https://carpentries-incubator.github.io/machine-learning-librarians-archivists/" target="_blank" class="icon-browser" title="Website for the Intro to AI for GLAM"></a></td>
-      <td><a href="https://github.com/carpentries-incubator/machine-learning-librarians-archivists" target="_blank" class="icon-github" title="Repository for Intro to AI for GLAM"></a></td>
-      <td><a href="https://carpentries-incubator.github.io/machine-learning-librarians-archivists/reference.html" target="_blank" class="icon-eye" title="Reference for Intro to AI for GLAMn"></a></td>
-      <td><a href="https://carpentries-incubator.github.io/machine-learning-librarians-archivists/guide/index.html" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for Intro to AI for GLAM"></a></td>
-      <td>Beta</td>
-      <td>Mark Bell, Nora McGregor, Daniel van Strien, Mike Trizna </td>
-   </tr>
-      <tr>
-      <td><acronym title="Data Management Plan">DMP</acronym> Course for Librarians</td>
-      <td><a href="http://librarycarpentry.org/lc-dmp101/" target="_blank" class="icon-browser" title="Website for DMP Course for Librarians"></a></td>
-      <td><a href="https://github.com/LibraryCarpentry/lc-dmp101" target="_blank" class="icon-github" title="Repository for DMP Course for Librarians "></a></td>
-      <td><a href="http://librarycarpentry.org/lc-dmp101/reference.html" target="_blank" class="icon-eye" title="Reference for DMP Course for Librarians"></a></td>
-      <td><a href="http://librarycarpentry.org/lc-dmp101/guide/index.html" target="_blank" class="icon-circle-with-plus" title="Instructor Notes for DMP Course for Librarians"></a></td>
-      <td>Alpha</td>
-      <td>Lena Bohman, Marla Hertz, Daria Orlowska</td>
-   </tr>
+      <td>SQL</td>
+      <td><a href="https://librarycarpentry.org/lc-sql/" target="_blank" class="icon-browser" title="Website for SQL lesson"></a></td>
+      <td><a href="https://github.com/librarycarpentry/lc-sql/" target="_blank" class="icon-github" title="Repository for SQL lesson"></a></td>
+      <td>Stable</td>
+      <td>4 to 5 hours</td>
+      <td>Julika Mimkes, Annajiat Alim Rasel</td>
+   </tr> 
 
 </table>
 <hr />
 
 <em>* Indicates Lead Maintainer</em>
 
-<br><br>
+<br>
 
 
 <h3 id="-retired-curriculum"><a id="retired-curriculum"></a>Retired Curriculum</h3>
 
 
-<p>The following Library Carpentry lessons are no longer maintained. There may be include out-of-date instructions or references
-   but content in these lessons could still be useful.
-   You may reach out to the <a href="/governance/#cac">Curriculum Advisory Committee</a> if you are interested in restarting these lessons
-   and becoming a new Maintainer. </p>
+<p>The following Library Carpentry lessons are no longer maintained and we do not recommend teaching them in their current state.  There may include out-of-date instructions or references. They are archived here since the content in these lessons could still be useful for adapting. Reach out to the <a href="/governance/#cac">Curriculum Advisory Committee</a> if you are interested in restarting any of these lessons and becoming a new Maintainer. </p>
 
 <table class="table table-striped">
    <tr>
@@ -258,85 +229,9 @@ Lesson materials are all available online, under a CC BY license, for self-direc
       <td></td>
    </tr>
 </table>
-<p>In addition, lessons on <a href="https://github.com/LibraryCarpentry/lc-dig-pres">Digital Preservation</a> and <a href="https://github.com/LibraryCarpentry/lc-tdm">Text and Data Mining</a> are being discussed.</p>
 <hr />
 
 <em>* Indicates Lead Maintainer</em>
 
-<h3 id="-lesson-status"><a id="lesson-status"></a>Lesson Status</h3>
+<br><br>
 
-<p>Our lessons are in various stages of development - stable, beta, alpha, and conceptual.</p>
-
-<h4 id="-lesson-stable"><a id="lesson-stable"></a>Stable</h4>
-
-<p>These lessons are mature and ready to be taught. Most have been taught multiple times. The content is well-established,
-but minor changes and improvements (e.g. better explanations, spelling/grammar corrections, improved exercises) are always welcome.</p>
-
-<h4 id="-lesson-beta"><a id="lesson-beta"></a>Beta</h4>
-
-<p>These lessons are largely complete and should be ready to teach, but would benefit from improvements based on feedback
-from instructors who have taught them. New sections and rewrites/reorganisations of existing sections will be considered.</p>
-
-<h4 id="-lesson-alpha"><a id="lesson-alpha"></a>Alpha</h4>
-
-<p>These lessons are under active development and may not be ready to teach without additional preparation and background knowledge.
-Further development work is strongly encouraged - please get in touch or check out outstanding issues on GitHub to find out
-   what is needed.</p>
-
-<h4 id="-lesson-conceptual"><a id="lesson-conceptual"></a>Conceptual</h4>
-
-<p>These lessons are still in the conceptual phase where community members have just started to discuss general ideas
-   , learner profiles, goals, summative and fomative assessments, concept maps, software and data to be used, how long the lesson
-   should be, and connecting the dots before moving to the <strong>alpha</strong> phase.</p>
-
-<h4 id="-lesson-contributing"><a id="lesson-contributing"></a>Contributing to Lessons</h4>
-
-<p>All contributions are welcome. The level of work may vary depending on the status of the lesson. We recommend that
-   you <strong>@mention</strong> the Maintainers of the lesson if you are picking up the tasks described in one of the open
-   lesson issues or pull requests.</p>
-
-<h4 id="-lesson-development"><a id="lesson-development"></a>Lesson Development Process</h4>
-
-<p><strong>Our recommended process for developing a new lesson is as follows:</strong>
-<ul>
-   <li>Develop the initial content on GitHub using the Carpentries' <a href="http://carpentries.github.io/lesson-example/setup.html">set up instructions</a> for new lessons.
-New lessons are built from clones of <a href="https://github.com/swcarpentry/styles">this repo</a>.
-   <li>Introduce yourself and the lesson on our <a href="https://gitter.im/LibraryCarpentry/Lobby">Gitter channel</a> or
-      <a href="https://carpentries.topicbox.com/groups/discuss-library-carpentry">Topicbox list</a>  — there may well be willing volunteers to help with the content.
-   <li>Teach the lesson, collect feedback, and perhaps raise issues or pull requests to improve the content.</li>
-   <li>Propose your lesson for the incubator by making a pull request (PR) against the Library Carpentry website, adding a
-link to your lesson repository as an <strong>alpha</strong> lesson.
-      <li>Discuss the lesson with the community and, if necessary, offer suggestions on how to improve the lesson;
-         if the lesson is considered suitable material for the Library Carpentry curriculum, a website maintainer will
-         merge your PR into the main site</li>
-   <li>You and others will teach the lesson, collect feedback, and improve the content.</li>
-   <li>Propose your lesson for beta/stable by making a pull request against the Library Carpentry website,
-      updating the status of your lesson.</li>
-   <li>Discuss the lesson further with the community; when the lesson is ready, a website maintainer will merge your
-      pull request(PR).</li>
-   <li>Congratulations! Your lesson is now part of stable Library Carpentry!</li>
-</ul>
-</p>
-
-<h4 id="-lesson-expectations"><a id="lesson-expectations"></a>New Lesson Expectations</h4>
-
-<p>In order to maintain consistent quality and style in the Library Carpentry lessons, we have a community-driven
-set of expectations for what a good lesson should look like. These should guide the review process at steps 5 and 8
-above. Lesson developers and reviewers should also review The Carpentries Handbook, especially the section on
-   <a href="https://docs.carpentries.org/topic_folders/lesson_development/index.html">Lesson Development</a> and consult with the <a href="/governance/#cac">Curriculum Advisory Committee</a>.</p>
-
-<h4 id="-stable-lessons"><a id="stable-lessons"></a>All stable lessons should:</h4>
-<p>
-<ul>
-   <li>have at least three active Maintainers.
-   <li>include a short <a href="">learner profile</a> (i.e. who the lesson is designed for).</li>
-   <li>include concrete learning objectives.</li>
-   <li>be teachable in around three hours under normal circumstances.</li>
-</ul>
-</p>
-
-<h3 id="community-lessons">Community Developed Lessons</h2>
-
-<p>
-The Carpentries also shares <a href="https://carpentries.org/community-lessons/">The Carpentries Community Developed Lessons</a>.  This includes <a href="https://carpentries.org/community-lessons/#the-carpentries-incubator">The Carpentries Incubator</a> (lessons under development and seeking peer review), and <a href="https://carpentries.org/community-lessons/#the-carpentrieslab">The CarpentriesLab</a> (lessons that have been vetted by The Carpentries but are not part of our standard offerings).
-</p>


### PR DESCRIPTION
Proposed updates to lessons page, for review by @LibraryCarpentry/curriculum-advisors. I will add this to agenda for the 2024-09-19 meeting and email the group. 

Updates to review:

- Major pruning and rewriting of explanatory text.
- Adding a column to lessons table for Length of lesson.
- Removing columns for Reference and Instructor Notes.
- Moved Introduction to Regular Expressions lesson to Extended Curriculum, and renamed it (removing Introduction to Data).

Note: this does not include any information about Pathways. That is for later work.